### PR TITLE
Fix startup checks

### DIFF
--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/Consumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/Consumer.java
@@ -53,10 +53,10 @@ public class Consumer {
         if (bootstrapServers == null) {
             throw new IllegalArgumentException("bootstrapServers config was not passed at startup");
         }
-        if (bootstrapServers == null) {
+        if (zkConnectString == null) {
             throw new IllegalArgumentException("zkConnectString config was not passed at startup");
         }
-        if (bootstrapServers == null) {
+        if (topicName == null) {
             throw new IllegalArgumentException("topicName config was not passed at startup");
         }
 


### PR DESCRIPTION
This change corrects the `if` statements in the consumer start, so that it
actually checks the config being passed.

Previously it just checked the `bootstrapServers` three times.