### PR TITLE
KafkaCrossDcConf: Add a human readable toString

### DIFF
--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaCrossDcConf.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaCrossDcConf.java
@@ -61,4 +61,17 @@ public class KafkaCrossDcConf extends CrossDcConf {
   public String getBootStrapServers() {
         return bootstrapServers;
   }
+
+    @Override
+    public String toString() {
+        return String.format("KafkaCrossDcConf{" +
+                "topicName='%s', " +
+                "enableDataEncryption='%b', " +
+                "bootstrapServers='%s', " +
+                "slowSubmitThresholdInMillis='%d', " +
+                "numOfRetries='%d', " +
+                "solrZkConnectString='%s'}",
+                topicName, enableDataEncryption, bootstrapServers,
+                slowSubmitThresholdInMillis, numOfRetries, solrZkConnectString);
+    }
 }


### PR DESCRIPTION
This change adds a human readable `toString` function to `KafkaCrossDcConf`.

Instead of seeing messages like this:
```
Configurations org.apache.solr.crossdc.common.KafkaCrossDcConf@7953c5d9
```

We now get:
```
Configurations KafkaCrossDcConf{topicName='topic1',
enableDataEncryption='false', bootstrapServers='127.0.0.1:57559',
slowSubmitThresholdInMillis='0', numOfRetries='5', solrZkConnectString='null'}
```