### PR TITLE
Reindex Test, cover a few more test cases, additional config options.

### DIFF
--- a/CROSSDC.md
+++ b/CROSSDC.md
@@ -103,13 +103,19 @@ The Kafka topicName used to indicate which Kafka queue the Solr updates will be 
 1. Uncompress the distribution tar or zip file for the CrossDC Consumer into an appropriate install location on a node in the receiving data center.
 2. You can start the Consumer process via the included shell start script at bin/crossdc-consumer.
 3. You can configure the CrossDC Consumer via Java system properties pass in the CROSSDC_CONSUMER_OPTS environment variable, i.e. CROSSDC_CONSUMER_OPTS="-DbootstrapServers=127.0.0.1:2181 -DzkConnectString=127.0.0.1:2181 -DtopicName=crossdc" bin/crossdc-consumer
-4. The required configuration properties are:
-5. *bootstrapServers* - the list of servers used to connect to the Kafka cluster
-6.  https://kafka.apache.org/28/documentation.html#producerconfigs_bootstrap.servers
-7. *topicName* - the Kafka topicName used to indicate which Kafka queue the Solr updates will be pushed to.
-8. *zkConnectString* - the Zookeeper connection string used by Solr to connect to its Zookeeper cluster in the backup data center
+
+The required configuration properties are:
 
 
+   *bootstrapServers* - the list of servers used to connect to the Kafka cluster https://kafka.apache.org/28/documentation.html#producerconfigs_bootstrap.servers
+
+   *topicName* - the Kafka topicName used to indicate which Kafka queue the Solr updates will be pushed to.
+
+   *zkConnectString* - the Zookeeper connection string used by Solr to connect to its Zookeeper cluster in the backup data center
+
+Additional configuration properties:
+
+   *groupId* - the group id to give Kafka for the consumer, default to the empty string if not specified.
 
 #### Central Configuration Option
 
@@ -119,7 +125,7 @@ You can optionally manage the configuration centrally in Solr's Zookeeper cluste
 
 Both *bootstrapServers* and *topicName* properties can be put in this file, in which case you would not have to specify any Kafka configuration in the solrconfig.xml for the CrossDC Producer Solr plugin. Likewise, for the CrossDC Consumer application, you would only have to set *zkConnectString* for the local Solr cluster. Note that the two components will be looking in the Zookeeper clusters in their respective data center locations.
 
-
+You can override the properties file location and znode name in Zookeeper using the system property *zkCrossDcPropsPath=/path/to/props_file_name.properties*
 
 #### Making the Cross DC UpdateProcessor Optional in a Common solrconfig.xml
 

--- a/CROSSDC.md
+++ b/CROSSDC.md
@@ -1,0 +1,185 @@
+# Solr Cross DC: Getting Started
+
+**A simple cross-data-center fail-over solution for Apache Solr.**
+
+
+
+[TOC]
+
+## Overview
+
+The design for this feature involves three key components:
+
+- A UpdateProccessor plugin for Solr to forward updates from the primary data center.
+- An update request consumer application to receive updates in the backup data center.
+- A distributed queue to connect the above two.
+
+The UpdateProcessor plugin is called the CrossDC Producer, the consumer application is called the CrossDC Consumer, and the supported distributed queue application is Apache Kafka.
+
+## Getting Started
+
+To use Solr Cross DC, you must complete the following steps:
+
+- Startup or obtain access to an Apache Kafka cluster to provide the distributed queue between data centers.
+- Install the CrossDC Solr plugin on each of the nodes in your Solr cluster (in your primary and backup data centers) by placing the jar in the correct location and configuring solrconfig.xml to reference the new UpdateProcessor and then configure it for the Kafka cluster.
+- Install the CrossDC consumer application in the backup data center and configure it for the Kafka cluster and the Solr cluster it will send consumed updates to.
+
+The Solr UpdateProccessor plugin will intercept updates when the node acts as the leader and then put those updates onto the distributed queue. The CrossDC Consumer application will poll the distributed queue and forward updates on to the configured Solr cluster upon receiving the update requests.
+
+### Configuration and Startup
+
+The current configuration options are entirely minimal. Further configuration options will be added over time. At this early stage, some may also change.
+
+#### Installing and Configuring the Cross DC Producer Solr Plug-In
+
+1. Configure the sharedLib directory in solr.xml (eg sharedLIb=lib) and place the CrossDC producer plug-in jar file into the specified folder. It's not advisable to attempt to use the per SolrCore instance directory lib folder as you would have to duplicate the plug-in many times and manage it when creating new collections or adding replicas or shards.
+
+
+**solr.xml**
+
+   ```xml
+   <solr>
+     <str name="sharedLib">${solr.sharedLib:}</str>
+   ```
+
+
+
+2. Configure the new UpdateProcessor in solrconfig.xml
+
+   **NOTE:** `The following is not the recommended configuration approach in production, see the information on central configuration below!`
+
+
+
+**solrconfig.xml**
+
+   ```xml
+   <updateRequestProcessorChain  name="mirrorUpdateChain" default="true">
+   
+     <processor class="org.apache.solr.update.processor.MirroringUpdateRequestProcessorFactory">
+       <str name="bootstrapServers">${bootstrapServers:}</str>
+       <str name="topicName">${topicName:}</str>
+     </processor>
+   
+     <processor class="solr.LogUpdateProcessorFactory" />
+     <processor class="solr.RunUpdateProcessorFactory" />
+   </updateRequestProcessorChain>
+   ```
+
+Notice that this update chain has been declared to be the default chain used.
+
+
+
+##### Configuration Properties
+
+There are two configuration properties. You can specify them directly, or use the above notation to allow them to specified via system property (generally configured for Solr in the bin/solr.in.sh file).
+
+   ```
+   bootstrapServers
+   ```
+
+The list of servers used to connect to the Kafka cluster, see https://kafka.apache.org/28/documentation.html#producerconfigs_bootstrap.servers
+
+   ```
+   topicName 
+   ```
+
+The Kafka topicName used to indicate which Kafka queue the Solr updates will be pushed on to.
+
+
+
+3. Add an external version constraint UpdateProcessor to the update chain added to solrconfig.xml to allow user-provided update versions (as opposed to the two Solr clusters using the independently managed built-in versioning).
+
+   https://solr.apache.org/guide/8_11/update-request-processors.html#general-use-updateprocessorfactories
+
+   https://solr.apache.org/docs/8_1_1/solr-core/org/apache/solr/update/processor/DocBasedVersionConstraintsProcessor.html
+
+
+4. Start or restart the Solr cluster(s).
+
+
+
+#### Installing and Configuring the CrossDC Consumer Application
+
+1. Uncompress the distribution tar or zip file for the CrossDC Consumer into an appropriate install location on a node in the receiving data center.
+2. You can start the Consumer process via the included shell start script at bin/crossdc-consumer.
+3. You can configure the CrossDC Consumer via Java system properties pass in the CROSSDC_CONSUMER_OPTS environment variable, i.e. CROSSDC_CONSUMER_OPTS="-DbootstrapServers=127.0.0.1:2181 -DzkConnectString=127.0.0.1:2181 -DtopicName=crossdc" bin/crossdc-consumer
+4. The required configuration properties are:
+5. *bootstrapServers* - the list of servers used to connect to the Kafka cluster
+6.  https://kafka.apache.org/28/documentation.html#producerconfigs_bootstrap.servers
+7. *topicName* - the Kafka topicName used to indicate which Kafka queue the Solr updates will be pushed to.
+8. *zkConnectString* - the Zookeeper connection string used by Solr to connect to its Zookeeper cluster in the backup data center
+
+
+
+#### Central Configuration Option
+
+You can optionally manage the configuration centrally in Solr's Zookeeper cluster by placing a properties file called *crossdc.properties* in the root Solr Zookeeper znode, eg, */solr/crossdc.properties*.  This allows you to update the configuration in a central location rather than at each solrconfig.xml in each Solr node and also automatically deals with new Solr nodes or Consumers to come up without requiring additional configuration.
+
+
+
+Both *bootstrapServers* and *topicName* properties can be put in this file, in which case you would not have to specify any Kafka configuration in the solrconfig.xml for the CrossDC Producer Solr plugin. Likewise, for the CrossDC Consumer application, you would only have to set *zkConnectString* for the local Solr cluster. Note that the two components will be looking in the Zookeeper clusters in their respective data center locations.
+
+
+
+#### Making the Cross DC UpdateProcessor Optional in a Common solrconfig.xml
+
+The simplest and least invasive way to control whether the Cross DC UpdateProcessor is on or off for a node is to configure the update chain it's used in to be the default chain or not via Solr's system property configuration syntax.  This syntax takes the form of ${*system_property_name*} and will be substituted with the value of that system property when the configuration is parsed. You can specify a default value using the following syntax: ${*system_property_name*:*default_value*}. You can use the same syntax and property name to specify whether or not the Cross DC UpdateRequestProcessor is enabled or not.
+
+*Having a separate updateRequestProcessorChain avoids a lot of additional constraints you have to deal with or consider, now or in the future, when compared to forcing all Cross DC and non-Cross DC use down a single, required, common updateRequestProcessorChain.*
+
+Further, any application consuming the configuration with no concern for enabling Cross DC will not be artificially limited in its ability to define, manage and use updateRequestProcessorChain's.
+
+The following would enable a system property to safely and non invasively enable or disable Cross DC for a node:
+
+
+```xml
+<updateRequestProcessorChain  name="crossdcUpdateChain" default="${crossdcEnabled:false}">
+  <processor class="org.apache.solr.update.processor.MirroringUpdateRequestProcessorFactory">
+    <bool name="enabled">${enabled:false}</bool>
+  </processor>
+  <processor class="solr.LogUpdateProcessorFactory" />
+  <processor class="solr.RunUpdateProcessorFactory" />
+</updateRequestProcessorChain>
+```
+
+
+
+The above configuration would default to Cross DC being disabled with minimal impact to any non-Cross DC use, and Cross DC could be enabled by starting Solr with the system property crossdcEnabled=true.
+
+The last chain to declare it's the default wins, so you can put this at the bottom of almost any existing solrconfig.xml to create an optional Cross DC path without having to audit, understand, adapt, or test existing non-Cross DC paths as other options call for.
+
+The above is the simplest and least obtrusive way to manage an on/off switch for Cross DC.
+
+**Note:** If your configuration already makes use of update handlers and/or updates independently specifying different updateRequestProcessorChains, your solution may end up a bit more sophisticated.
+
+
+
+For situations where you do want to control and enforce a single updateRequestProcessorChain path for every consumer of the solrconfig.xml, it's enough to simply use the *enabled* attribute, turning the processor into a NOOP in the chain.
+
+
+
+```xml
+<updateRequestProcessorChain  name="crossdcUpdateChain">
+  <processor class="org.apache.solr.update.processor.MirroringUpdateRequestProcessorFactory">
+    <bool name="enabled">${enabled:false}</bool>
+  </processor>
+  <processor class="solr.LogUpdateProcessorFactory" />
+  <processor class="solr.RunUpdateProcessorFactory" />
+</updateRequestProcessorChain>
+```
+
+
+
+## Limitations
+
+- Delete-By-Query is not officially supported.
+
+    - Work-In-Progress: A non-efficient option to issue multiple delete by id queries using the results of a given standard query.
+
+    - Simply forwarding a real Delete-By-Query could also be reasonable if it is not strictly reliant on not being reordered with other requests.
+
+
+
+## Additional Notes
+
+In these early days, it may help to reference the *cluster.sh* script located in the root of the CrossDC repository. This script is a helpful developer tool for manual testing and it will download Solr and Kafka and then configure both for Cross DC.

--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/CrossDcConf.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/CrossDcConf.java
@@ -18,6 +18,7 @@ package org.apache.solr.crossdc.common;
 
 public abstract class CrossDcConf {
     public static final String CROSSDC_PROPERTIES = "/crossdc.properties";
+    public static final String ZK_CROSSDC_PROPS_PATH = "zkCrossDcPropsPath";
 
     public abstract String getClusterName();
 }

--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaCrossDcConf.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaCrossDcConf.java
@@ -26,13 +26,15 @@ public class KafkaCrossDcConf extends CrossDcConf {
     private int numOfRetries = 5;
     private final String solrZkConnectString;
 
+    private final int maxPollRecords;
 
-    public KafkaCrossDcConf(String bootstrapServers, String topicName, String groupId, boolean enableDataEncryption, String solrZkConnectString) {
+    public KafkaCrossDcConf(String bootstrapServers, String topicName, String groupId, int maxPollRecords, boolean enableDataEncryption, String solrZkConnectString) {
         this.bootstrapServers = bootstrapServers;
         this.topicName = topicName;
         this.enableDataEncryption = enableDataEncryption;
         this.solrZkConnectString = solrZkConnectString;
         this.groupId = groupId;
+        this.maxPollRecords = maxPollRecords;
     }
     public String getTopicName() {
         return topicName;
@@ -64,6 +66,10 @@ public class KafkaCrossDcConf extends CrossDcConf {
     public String getGroupId() {
         return groupId;
   }
+
+    public int getMaxPollRecords() {
+        return maxPollRecords;
+    }
 
     public String getBootStrapServers() {
         return bootstrapServers;

--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaCrossDcConf.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaCrossDcConf.java
@@ -18,6 +18,8 @@ package org.apache.solr.crossdc.common;
 
 public class KafkaCrossDcConf extends CrossDcConf {
     private final String topicName;
+
+    private final String groupId;
     private final boolean enableDataEncryption;
     private final String bootstrapServers;
     private long slowSubmitThresholdInMillis;
@@ -25,11 +27,12 @@ public class KafkaCrossDcConf extends CrossDcConf {
     private final String solrZkConnectString;
 
 
-    public KafkaCrossDcConf(String bootstrapServers, String topicName, boolean enableDataEncryption, String solrZkConnectString) {
+    public KafkaCrossDcConf(String bootstrapServers, String topicName, String groupId, boolean enableDataEncryption, String solrZkConnectString) {
         this.bootstrapServers = bootstrapServers;
         this.topicName = topicName;
         this.enableDataEncryption = enableDataEncryption;
         this.solrZkConnectString = solrZkConnectString;
+        this.groupId = groupId;
     }
     public String getTopicName() {
         return topicName;
@@ -58,20 +61,25 @@ public class KafkaCrossDcConf extends CrossDcConf {
         return null;
     }
 
-  public String getBootStrapServers() {
-        return bootstrapServers;
+    public String getGroupId() {
+        return groupId;
   }
+
+    public String getBootStrapServers() {
+        return bootstrapServers;
+    }
 
     @Override
     public String toString() {
         return String.format("KafkaCrossDcConf{" +
                 "topicName='%s', " +
+                "groupId='%s', " +
                 "enableDataEncryption='%b', " +
                 "bootstrapServers='%s', " +
                 "slowSubmitThresholdInMillis='%d', " +
                 "numOfRetries='%d', " +
                 "solrZkConnectString='%s'}",
-                topicName, enableDataEncryption, bootstrapServers,
+                topicName, groupId, enableDataEncryption, bootstrapServers,
                 slowSubmitThresholdInMillis, numOfRetries, solrZkConnectString);
     }
 }

--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaMirroringSink.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/KafkaMirroringSink.java
@@ -56,7 +56,10 @@ public class KafkaMirroringSink implements RequestMirroringSink, Closeable {
         try {
 
             producer.send(new ProducerRecord(conf.getTopicName(), request), (metadata, exception) -> {
-                log.info("Producer finished sending metadata={}, exception={}", metadata, exception);
+                if (log.isDebugEnabled()) {
+                    log.debug("Producer finished sending metadata={}, exception={}", metadata,
+                        exception);
+                }
             });
             producer.flush(); // TODO: remove
 

--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/MirroredSolrRequestSerializer.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/MirroredSolrRequestSerializer.java
@@ -62,7 +62,10 @@ public class MirroredSolrRequestSerializer implements Serializer<MirroredSolrReq
         try {
             solrRequest = (Map) codec.unmarshal(bais);
 
-            log.info("Deserialized class={} solrRequest={}", solrRequest.getClass().getName(), solrRequest);
+            if (log.isTraceEnabled()) {
+                log.trace("Deserialized class={} solrRequest={}", solrRequest.getClass().getName(),
+                    solrRequest);
+            }
 
 
         } catch (Exception e) {

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/Consumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/Consumer.java
@@ -40,6 +40,7 @@ public class Consumer {
     public static final String GROUP_ID = "groupId";
     public static final String PORT = "port";
     public static final String BOOTSTRAP_SERVERS = "bootstrapServers";
+    private static final String DEFAULT_GROUP_ID = "SolrCrossDCConsumer";
 
     private static boolean enabled = true;
 
@@ -104,13 +105,13 @@ public class Consumer {
         // boolean enableDataEncryption = Boolean.getBoolean("enableDataEncryption");
         String topicName = System.getProperty(TOPIC_NAME);
         String port = System.getProperty(PORT);
-        String groupId = System.getProperty(GROUP_ID);
+        String groupId = System.getProperty(GROUP_ID, "");
 
 
         try (SolrZkClient client = new SolrZkClient(zkConnectString, 15000)) {
 
             try {
-                if ((topicName == null || topicName.isBlank())
+                if ((topicName == null || topicName.isBlank()) || (groupId == null || groupId.isBlank())
                     || (bootstrapServers == null || bootstrapServers.isBlank()) || (port == null || port.isBlank()) && client
                     .exists(System.getProperty(CrossDcConf.ZK_CROSSDC_PROPS_PATH, KafkaCrossDcConf.CROSSDC_PROPERTIES), true)) {
                     byte[] data = client.getData(System.getProperty(CrossDcConf.ZK_CROSSDC_PROPS_PATH, KafkaCrossDcConf.CROSSDC_PROPERTIES), null, null, true);
@@ -139,6 +140,10 @@ public class Consumer {
         }
         if (topicName == null || topicName.isBlank()) {
             throw new IllegalArgumentException("topicName not specified for producer");
+        }
+
+        if (groupId.isBlank()) {
+            groupId = DEFAULT_GROUP_ID;
         }
 
         Consumer consumer = new Consumer();

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
@@ -49,7 +49,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
 
     kafkaConsumerProp.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, conf.getBootStrapServers());
 
-    kafkaConsumerProp.put(ConsumerConfig.GROUP_ID_CONFIG, "group_1"); // TODO
+    kafkaConsumerProp.put(ConsumerConfig.GROUP_ID_CONFIG, conf.getGroupId()); // TODO
 
     kafkaConsumerProp.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
@@ -51,6 +51,8 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
 
     kafkaConsumerProp.put(ConsumerConfig.GROUP_ID_CONFIG, conf.getGroupId());
 
+    kafkaConsumerProp.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, conf.getMaxPollRecords());
+
     kafkaConsumerProp.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     solrClient =

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
@@ -49,7 +49,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
 
     kafkaConsumerProp.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, conf.getBootStrapServers());
 
-    kafkaConsumerProp.put(ConsumerConfig.GROUP_ID_CONFIG, conf.getGroupId()); // TODO
+    kafkaConsumerProp.put(ConsumerConfig.GROUP_ID_CONFIG, conf.getGroupId());
 
     kafkaConsumerProp.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 

--- a/crossdc-producer/src/main/java/org/apache/solr/update/processor/KafkaRequestMirroringHandler.java
+++ b/crossdc-producer/src/main/java/org/apache/solr/update/processor/KafkaRequestMirroringHandler.java
@@ -34,7 +34,7 @@ public class KafkaRequestMirroringHandler implements RequestMirroringHandler {
     final KafkaMirroringSink sink;
 
     public KafkaRequestMirroringHandler(KafkaMirroringSink sink) {
-        log.info("create KafkaRequestMirroringHandler");
+        log.debug("create KafkaRequestMirroringHandler");
         this.sink = sink;
     }
 

--- a/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateProcessor.java
+++ b/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateProcessor.java
@@ -221,7 +221,7 @@ public class MirroringUpdateProcessor extends UpdateRequestProcessor {
   }
 
   public void processCommit(CommitUpdateCommand cmd) throws IOException {
-    log.info("process commit cmd={}", cmd);
+    log.debug("process commit cmd={}", cmd);
     if (next != null) next.processCommit(cmd);
   }
 

--- a/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateRequestProcessorFactory.java
+++ b/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateRequestProcessorFactory.java
@@ -111,8 +111,8 @@ public class MirroringUpdateRequestProcessorFactory extends UpdateRequestProcess
 
         try {
             if (((topicName == null || topicName.isBlank()) || (bootstrapServers == null || bootstrapServers.isBlank())) && core.getCoreContainer().getZkController()
-                .getZkClient().exists(CrossDcConf.CROSSDC_PROPERTIES, true)) {
-                byte[] data = core.getCoreContainer().getZkController().getZkClient().getData("/crossdc.properties", null, null, true);
+                .getZkClient().exists(System.getProperty(CrossDcConf.ZK_CROSSDC_PROPS_PATH, KafkaCrossDcConf.CROSSDC_PROPERTIES), true)) {
+                byte[] data = core.getCoreContainer().getZkController().getZkClient().getData(System.getProperty(CrossDcConf.ZK_CROSSDC_PROPS_PATH, KafkaCrossDcConf.CROSSDC_PROPERTIES), null, null, true);
 
                 if (data == null) {
                     log.error("crossdc.properties file in Zookeeper has no data");
@@ -153,7 +153,7 @@ public class MirroringUpdateRequestProcessorFactory extends UpdateRequestProcess
         // load the request mirroring sink class and instantiate.
        // mirroringHandler = core.getResourceLoader().newInstance(RequestMirroringHandler.class.getName(), KafkaRequestMirroringHandler.class);
 
-        KafkaCrossDcConf conf = new KafkaCrossDcConf(bootstrapServers, topicName, false, null);
+        KafkaCrossDcConf conf = new KafkaCrossDcConf(bootstrapServers, topicName, "group1", false, null);
         KafkaMirroringSink sink = new KafkaMirroringSink(conf);
 
         Closer closer = new Closer(sink);

--- a/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateRequestProcessorFactory.java
+++ b/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateRequestProcessorFactory.java
@@ -153,7 +153,7 @@ public class MirroringUpdateRequestProcessorFactory extends UpdateRequestProcess
         // load the request mirroring sink class and instantiate.
        // mirroringHandler = core.getResourceLoader().newInstance(RequestMirroringHandler.class.getName(), KafkaRequestMirroringHandler.class);
 
-        KafkaCrossDcConf conf = new KafkaCrossDcConf(bootstrapServers, topicName, "group1", false, null);
+        KafkaCrossDcConf conf = new KafkaCrossDcConf(bootstrapServers, topicName, "",  -1, false,  null);
         KafkaMirroringSink sink = new KafkaMirroringSink(conf);
 
         Closer closer = new Closer(sink);
@@ -214,7 +214,7 @@ public class MirroringUpdateRequestProcessorFactory extends UpdateRequestProcess
         if (log.isTraceEnabled()) {
             log.trace("Create MirroringUpdateProcessor with mirroredParams={}", mirroredParams);
         }
-        log.info("Create MirroringUpdateProcessor");
+
         return new MirroringUpdateProcessor(next, doMirroring, mirroredParams,
                 DistribPhase.parseParam(req.getParams().get(DISTRIB_UPDATE_PARAM)), doMirroring ? mirroringHandler : null);
     }

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/DeleteByQueryToIdTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/DeleteByQueryToIdTest.java
@@ -104,7 +104,7 @@ import java.util.Properties;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", -1,false, 0);
 
   }
 

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/DeleteByQueryToIdTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/DeleteByQueryToIdTest.java
@@ -104,7 +104,7 @@ import java.util.Properties;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", false, 0);
 
   }
 

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
@@ -106,7 +106,7 @@ import java.util.Properties;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC,  "group1", false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC,  "group1", -1,false, 0);
   }
 
   private static MiniSolrCloudCluster startCluster(MiniSolrCloudCluster solrCluster, ZkTestServer zkTestServer, Path baseDir) throws Exception {

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
@@ -106,7 +106,7 @@ import java.util.Properties;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC,  "group1", false, 0);
   }
 
   private static MiniSolrCloudCluster startCluster(MiniSolrCloudCluster solrCluster, ZkTestServer zkTestServer, Path baseDir) throws Exception {

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaIntegrationTest.java
@@ -99,7 +99,7 @@ import static org.mockito.Mockito.spy;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1",false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", -1, false, 0);
 
   }
 

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaReindexTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaReindexTest.java
@@ -91,7 +91,7 @@ import java.util.Properties;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", -1,false, 0);
 
   }
 

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/ZkConfigIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/ZkConfigIntegrationTest.java
@@ -108,7 +108,7 @@ import java.util.Properties;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", -1, false, 0);
 
   }
 

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/ZkConfigIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/ZkConfigIntegrationTest.java
@@ -108,7 +108,7 @@ import java.util.Properties;
     String bootstrapServers = kafkaCluster.bootstrapServers();
     log.info("bootstrapServers={}", bootstrapServers);
 
-    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, false, 0);
+    consumer.start(bootstrapServers, solrCluster2.getZkServer().getZkAddress(), TOPIC, "group1", false, 0);
 
   }
 


### PR DESCRIPTION
Adds a basic test focused on reindexing, covers a few more test cases: more replicas and shards, different shard count on primary and secondary dc, allows consumer group to be configured, allows crossdc zk prop file location to be configured.