### PR TITLE
Check docSize against max before mirroring

### DIFF
--- a/crossdc-producer/src/test/resources/configs/cloud-minimal/conf/solrconfig.xml
+++ b/crossdc-producer/src/test/resources/configs/cloud-minimal/conf/solrconfig.xml
@@ -111,6 +111,7 @@
   <updateRequestProcessorChain  name="mirrorUpdateChain" default="true">
     <processor class="org.apache.solr.update.processor.MirroringUpdateRequestProcessorFactory">
       <bool name="enabled">${enabled:true}</bool>
+      <bool name="indexUnmirrorableDocs">${indexUnmirrorableDocs:false}</bool>
       <str name="bootstrapServers">${bootstrapServers:}</str>
       <str name="topicName">${topicName:}</str>
     </processor>


### PR DESCRIPTION
Prior to this commit, the MirroringUpdateProcessor had no check to ensure that docs weren't running afoul of the batch size limit set at the Kafka level.

This commit changes this to ensure that docs exceeding this limit are not mirrored.  These offending docs may still be indexed, based on the value of the URP's "indexUnmirrorableDocs" config property (which defaults to 'false' if not set).