### PR TITLE
Fix log message printed when mirroring skipped for large doc

### DIFF
--- a/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateProcessor.java
+++ b/crossdc-producer/src/main/java/org/apache/solr/update/processor/MirroringUpdateProcessor.java
@@ -112,7 +112,7 @@ public class MirroringUpdateProcessor extends UpdateRequestProcessor {
     boolean isLeader = isLeader(cmd.getReq(),  cmd.getIndexedIdStr(), null, cmd.getSolrInputDocument());
     if (doMirroring && isLeader) {
       if (tooLargeForKafka) {
-        log.warn("Skipping mirroring of doc {} because estimated size exceeds batch size limit {} bytes", maxDocSizeBytes);
+        log.warn("Skipping mirroring of doc {} because estimated size exceeds batch size limit {} bytes", cmd.getPrintableId(), maxDocSizeBytes);
       } else {
         createAndOrGetMirrorRequest().add(doc, cmd.commitWithin, cmd.overwrite);
       }


### PR DESCRIPTION
The logging call was missing a needed template argument for the docId. 