### PR TITLE
Add 'collection' MDC to more consumer logs

### DIFF
--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessor.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessor.java
@@ -34,6 +34,7 @@ import org.apache.solr.crossdc.common.MirroredSolrRequest;
 import org.apache.solr.crossdc.common.SolrExceptionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
@@ -63,11 +64,13 @@ public class SolrMessageProcessor extends MessageProcessor implements IQueueHand
 
     @Override
     public Result<MirroredSolrRequest> handleItem(MirroredSolrRequest mirroredSolrRequest) {
-        connectToSolrIfNeeded();
+        try (final MDC.MDCCloseable mdc = MDC.putCloseable("collection", getCollectionFromRequest(mirroredSolrRequest))) {
+            connectToSolrIfNeeded();
 
-        // preventCircularMirroring(mirroredSolrRequest); TODO: isn't this handled by the mirroring handler?
+            // preventCircularMirroring(mirroredSolrRequest); TODO: isn't this handled by the mirroring handler?
 
-        return processMirroredRequest(mirroredSolrRequest);
+            return processMirroredRequest(mirroredSolrRequest);
+        }
     }
 
     private Result<MirroredSolrRequest> processMirroredRequest(MirroredSolrRequest request) {
@@ -348,4 +351,9 @@ public class SolrMessageProcessor extends MessageProcessor implements IQueueHand
         }
     }
 
+    private static String getCollectionFromRequest(MirroredSolrRequest mirroredSolrRequest) {
+        if (mirroredSolrRequest == null || mirroredSolrRequest.getSolrRequest() == null) return null;
+
+        return mirroredSolrRequest.getSolrRequest().getCollection();
+    }
 }


### PR DESCRIPTION
As-is, much of the producer logging is unhelpful without being able to discern which collections are receiving traffic.