### PR TITLE
Encryption KeySupplier supports params to get the key cookie.

### DIFF
--- a/ENCRYPTION.md
+++ b/ENCRYPTION.md
@@ -62,7 +62,7 @@ the Encryption plug-in jar file into the specified folder.
 
     <directoryFactory name="DirectoryFactory"
                       class="org.apache.solr.encryption.EncryptionDirectoryFactory">
-        <str name="keyManagerSupplier">com.yourApp.YourKeyManager$Supplier</str>
+        <str name="keySupplierFactory">com.yourApp.YourKeySupplier$Factory</str>
         <str name="encrypterFactory">org.apache.solr.encryption.crypto.CipherAesCtrEncrypter$Factory</str>
     </directoryFactory>
 
@@ -81,8 +81,8 @@ the Encryption plug-in jar file into the specified folder.
 
 `EncryptionDirectoryFactory` is the DirectoryFactory that encrypts/decrypts all (or some) the index files.
 
-`keyManagerSupplier` is a required parameter to specify your implementation of
-`org.apache.solr.encryption.KeyManager.Supplier`. This class is used to get your `KeyManager`.
+`keySupplierFactory` is a required parameter to specify your implementation of
+`org.apache.solr.encryption.KeySupplier.Factory`. This class is used to get your `KeySupplier`.
 
 `encrypterFactory` is an optional parameter to specify the `org.apache.solr.encryption.crypto.AesCtrEncrypterFactory`
 to use. By default `CipherAesCtrEncrypter$Factory` is used. You can change to `LightAesCtrEncrypter$Factory` for a

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectoryFactory.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectoryFactory.java
@@ -31,15 +31,15 @@ import java.io.IOException;
  * <p/>
  * To be configured with two parameters:
  * <ul>
- *   <li>{@link #PARAM_KEY_MANAGER_SUPPLIER} defines the {@link KeyManager.Supplier} to use.
+ *   <li>{@link #PARAM_KEY_SUPPLIER_FACTORY} defines the {@link KeySupplier.Factory} to use.
  *   Required.</li>
  *   <li>{@link #PARAM_ENCRYPTER_FACTORY} defines which {@link AesCtrEncrypterFactory} to use.
- *   Default is {@link CipherAesCtrEncrypter.Factory}.</li>
+ *   Optional; default is {@link CipherAesCtrEncrypter.Factory}.</li>
  * </ul>
  * <pre>
  *   <directoryFactory name="DirectoryFactory"
  *       class="${solr.directoryFactory:org.apache.solr.encryption.EncryptionDirectoryFactory}">
- *     <str name="keyManagerSupplier">${solr.keyManagerSupplier:com.myproject.MyKeyManagerSupplier}</str>
+ *     <str name="keySupplierFactory">${solr.keySupplierFactory:com.myproject.MyKeySupplierFactory}</str>
  *     <str name="encrypterFactory">${solr.encrypterFactory:org.apache.solr.encryption.crypto.LightAesCtrEncrypter$Factory}</str>
  *   </directoryFactory>
  * </pre>
@@ -54,14 +54,14 @@ public class EncryptionDirectoryFactory extends MMapDirectoryFactory {
   //  Right now, EncryptionDirectoryFactory extends MMapDirectoryFactory. And we hope we will
   //  refactor later.
 
-  public static final String PARAM_KEY_MANAGER_SUPPLIER = "keyManagerSupplier";
+  public static final String PARAM_KEY_SUPPLIER_FACTORY = "keySupplierFactory";
   public static final String PARAM_ENCRYPTER_FACTORY = "encrypterFactory";
   /**
    * Visible for tests only - Property defining the class name of the inner encryption directory factory.
    */
   static final String PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY = "innerEncryptionDirectoryFactory";
 
-  private KeyManager keyManager;
+  private KeySupplier keySupplier;
   private AesCtrEncrypterFactory encrypterFactory;
   private InnerFactory innerFactory;
 
@@ -70,14 +70,14 @@ public class EncryptionDirectoryFactory extends MMapDirectoryFactory {
     super.init(args);
     SolrParams params = args.toSolrParams();
 
-    String keyManagerSupplierClass = params.get(PARAM_KEY_MANAGER_SUPPLIER);
-    if (keyManagerSupplierClass == null) {
-      throw new IllegalArgumentException("Missing " + PARAM_KEY_MANAGER_SUPPLIER + " argument for " + getClass().getName());
+    String keySupplierFactoryClass = params.get(PARAM_KEY_SUPPLIER_FACTORY, System.getProperty("solr." + PARAM_KEY_SUPPLIER_FACTORY));
+    if (keySupplierFactoryClass == null) {
+      throw new IllegalArgumentException("Missing " + PARAM_KEY_SUPPLIER_FACTORY + " argument for " + getClass().getName());
     }
-    KeyManager.Supplier keyManagerSupplier = coreContainer.getResourceLoader().newInstance(keyManagerSupplierClass,
-                                                                                           KeyManager.Supplier.class);
-    keyManagerSupplier.init(args);
-    keyManager = keyManagerSupplier.getKeyManager();
+    KeySupplier.Factory keySupplierFactory = coreContainer.getResourceLoader().newInstance(keySupplierFactoryClass,
+                                                                                          KeySupplier.Factory.class);
+    keySupplierFactory.init(params);
+    keySupplier = keySupplierFactory.create();
 
     String encrypterFactoryClass = params.get(PARAM_ENCRYPTER_FACTORY, CipherAesCtrEncrypter.Factory.class.getName());
     encrypterFactory = coreContainer.getResourceLoader().newInstance(encrypterFactoryClass,
@@ -104,21 +104,21 @@ public class EncryptionDirectoryFactory extends MMapDirectoryFactory {
     }
   }
 
-  /** Gets the {@link KeyManager} used by this factory and all the encryption directories it creates. */
-  public KeyManager getKeyManager() {
-    return keyManager;
+  /** Gets the {@link KeySupplier} used by this factory and all the encryption directories it creates. */
+  public KeySupplier getKeySupplier() {
+    return keySupplier;
   }
 
   @Override
   protected Directory create(String path, LockFactory lockFactory, DirContext dirContext) throws IOException {
-    return innerFactory.create(super.create(path, lockFactory, dirContext), encrypterFactory, getKeyManager());
+    return innerFactory.create(super.create(path, lockFactory, dirContext), encrypterFactory, getKeySupplier());
   }
 
   /**
    * Visible for tests only - Inner factory that creates {@link EncryptionDirectory} instances.
    */
   interface InnerFactory {
-    EncryptionDirectory create(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeyManager keyManager)
+    EncryptionDirectory create(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeySupplier keySupplier)
       throws IOException;
   }
 }

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectoryFactory.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectoryFactory.java
@@ -18,7 +18,6 @@ package org.apache.solr.encryption;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
-import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.MMapDirectoryFactory;
 import org.apache.solr.encryption.crypto.AesCtrEncrypterFactory;
@@ -68,18 +67,17 @@ public class EncryptionDirectoryFactory extends MMapDirectoryFactory {
   @Override
   public void init(NamedList<?> args) {
     super.init(args);
-    SolrParams params = args.toSolrParams();
 
-    String keySupplierFactoryClass = params.get(PARAM_KEY_SUPPLIER_FACTORY, System.getProperty("solr." + PARAM_KEY_SUPPLIER_FACTORY));
+    String keySupplierFactoryClass = args._getStr(PARAM_KEY_SUPPLIER_FACTORY, System.getProperty("solr." + PARAM_KEY_SUPPLIER_FACTORY));
     if (keySupplierFactoryClass == null) {
       throw new IllegalArgumentException("Missing " + PARAM_KEY_SUPPLIER_FACTORY + " argument for " + getClass().getName());
     }
     KeySupplier.Factory keySupplierFactory = coreContainer.getResourceLoader().newInstance(keySupplierFactoryClass,
                                                                                           KeySupplier.Factory.class);
-    keySupplierFactory.init(params);
+    keySupplierFactory.init(args);
     keySupplier = keySupplierFactory.create();
 
-    String encrypterFactoryClass = params.get(PARAM_ENCRYPTER_FACTORY, CipherAesCtrEncrypter.Factory.class.getName());
+    String encrypterFactoryClass = args._getStr(PARAM_ENCRYPTER_FACTORY, CipherAesCtrEncrypter.Factory.class.getName());
     encrypterFactory = coreContainer.getResourceLoader().newInstance(encrypterFactoryClass,
                                                                      AesCtrEncrypterFactory.class);
     if (!encrypterFactory.isSupported()) {

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionRequestHandler.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionRequestHandler.java
@@ -74,7 +74,7 @@ public class EncryptionRequestHandler extends RequestHandlerBase {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   /**
-   * Key id request parameter.
+   * Key id request parameter - required.
    * Its value should be {@link #NO_KEY_ID} for no key.
    */
   public static final String PARAM_KEY_ID = "encryptionKeyId";
@@ -169,12 +169,19 @@ public class EncryptionRequestHandler extends RequestHandlerBase {
     } else if (keyId.equals(NO_KEY_ID)) {
       keyId = null;
     }
+    if (!(req.getCore().getDirectoryFactory() instanceof EncryptionDirectoryFactory)) {
+      throw new SolrException(SolrException.ErrorCode.SERVICE_UNAVAILABLE,
+                              DirectoryFactory.class.getSimpleName()
+                                + " must be configured with an "
+                                + EncryptionDirectoryFactory.class.getSimpleName()
+                                + " to use " + getClass().getSimpleName());
+    }
     boolean success = false;
     String encryptionState = STATE_PENDING;
     try {
       SegmentInfos segmentInfos = readLatestCommit(req.getCore());
       if (segmentInfos.size() == 0) {
-        commitEmptyIndexForEncryption(keyId, segmentInfos, req);
+        commitEmptyIndexForEncryption(keyId, segmentInfos, req, rsp);
         encryptionState = STATE_COMPLETE;
         success = true;
         return;
@@ -214,7 +221,7 @@ public class EncryptionRequestHandler extends RequestHandlerBase {
         pendingEncryptions.put(req.getCore().getName(), new PendingKeyId(keyId));
       }
       try {
-        commitEncryptionStart(keyId, segmentInfos, req);
+        commitEncryptionStart(keyId, segmentInfos, req, rsp);
         encryptAsync(req, startTimeMs);
         success = true;
       } finally {
@@ -238,36 +245,39 @@ public class EncryptionRequestHandler extends RequestHandlerBase {
 
   private void commitEmptyIndexForEncryption(@Nullable String keyId,
                                              SegmentInfos segmentInfos,
-                                             SolrQueryRequest req) throws IOException {
+                                             SolrQueryRequest req,
+                                             SolrQueryResponse rsp) throws IOException {
     // Commit no change, with the new active key id in the commit user data.
     log.debug("commit on empty index for keyId={}", keyId);
     CommitUpdateCommand commitCmd = new CommitUpdateCommand(req, false);
     commitCmd.commitData = new HashMap<>(segmentInfos.getUserData());
     commitCmd.commitData.remove(COMMIT_ENCRYPTION_PENDING);
-    setNewActiveKeyIdInCommit(keyId, commitCmd, req);
+    setNewActiveKeyIdInCommit(keyId, commitCmd, req, rsp);
     assert !commitCmd.commitData.isEmpty();
     req.getCore().getUpdateHandler().commit(commitCmd);
   }
 
-  private void setNewActiveKeyIdInCommit(String keyId, CommitUpdateCommand commitCmd, SolrQueryRequest req)
-    throws IOException {
+  private void setNewActiveKeyIdInCommit(String keyId,
+                                         CommitUpdateCommand commitCmd,
+                                         SolrQueryRequest req,
+                                         SolrQueryResponse rsp) throws IOException {
     if (keyId == null) {
       removeActiveKeyRefFromCommit(commitCmd.commitData);
       ensureNonEmptyCommitDataForEmptyCommit(commitCmd.commitData);
     } else {
-      byte[] keyCookie = getKeyManager(req).getKeyCookie(keyId);
+      KeySupplier keySupplier = ((EncryptionDirectoryFactory) req.getCore().getDirectoryFactory()).getKeySupplier();
+      Map<String, String> keyCookie = keySupplier.getKeyCookie(keyId, buildGetCookieParams(req, rsp));
       EncryptionUtil.setNewActiveKeyIdInCommit(keyId, keyCookie, commitCmd.commitData);
     }
   }
 
-  private KeyManager getKeyManager(SolrQueryRequest req) {
-    try {
-      return ((EncryptionDirectoryFactory) req.getCore().getDirectoryFactory()).getKeyManager();
-    } catch (ClassCastException e) {
-      throw new SolrException(SolrException.ErrorCode.SERVICE_UNAVAILABLE,
-                              "DirectoryFactory class must be set to " + EncryptionDirectoryFactory.class.getName() + " to use " + getClass().getSimpleName(),
-                              e);
-    }
+  /**
+   * Can be extended to build cookie params based on the request.
+   * If a required param is missing, it throws an exception and sets the response status to failure.
+   */
+  protected Map<String, String> buildGetCookieParams(SolrQueryRequest req, SolrQueryResponse rsp)
+    throws IOException {
+    return null;
   }
 
   private void commitEncryptionComplete(String keyId,
@@ -295,12 +305,13 @@ public class EncryptionRequestHandler extends RequestHandlerBase {
 
   private void commitEncryptionStart(String keyId,
                                      SegmentInfos segmentInfos,
-                                     SolrQueryRequest req) throws IOException {
+                                     SolrQueryRequest req,
+                                     SolrQueryResponse rsp) throws IOException {
     log.debug("commit encryption starting for keyId={}", keyId);
     CommitUpdateCommand commitCmd = new CommitUpdateCommand(req, false);
     commitCmd.commitData = new HashMap<>(segmentInfos.getUserData());
     commitCmd.commitData.put(COMMIT_ENCRYPTION_PENDING, "true");
-    setNewActiveKeyIdInCommit(keyId, commitCmd, req);
+    setNewActiveKeyIdInCommit(keyId, commitCmd, req, rsp);
     req.getCore().getUpdateHandler().commit(commitCmd);
   }
 

--- a/encryption/src/main/java/org/apache/solr/encryption/KeySupplier.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/KeySupplier.java
@@ -19,6 +19,7 @@ package org.apache.solr.encryption;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.util.plugin.NamedListInitializedPlugin;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -69,10 +70,10 @@ public interface KeySupplier {
   /**
    * Creates {@link KeySupplier}.
    */
-  interface Factory {
+  interface Factory extends NamedListInitializedPlugin {
 
     /** This factory may be configured with parameters defined in solrconfig.xml. */
-    void init(SolrParams params);
+    void init(NamedList<?> args);
 
     /** Creates a {@link KeySupplier}. */
     KeySupplier create();

--- a/encryption/src/main/java/org/apache/solr/encryption/KeySupplier.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/KeySupplier.java
@@ -17,59 +17,64 @@
 package org.apache.solr.encryption;
 
 import org.apache.lucene.index.IndexFileNames;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Manages encryption keys and defines which index files to encrypt.
- * Supplies the encryption key secrets corresponding to provided key ids.
+ * Provides encryption key secrets corresponding to provided key ids and defines which index files to encrypt.
  */
-public interface KeyManager {
+public interface KeySupplier {
 
   /**
-   * Indicates whether the provided file is encryptable based on its name.
+   * Indicates whether the provided file should be encrypted based on its name.
    * <p/>
    * Segments files ({@link IndexFileNames#SEGMENTS} or {@link IndexFileNames#PENDING_SEGMENTS}) are never
    * passed as parameter because they are filtered before calling this method (they must not be encrypted).
    */
-  boolean isEncryptable(String fileName);
+  boolean shouldEncrypt(String fileName);
 
   /**
-   * Gets the cookie corresponding to a given key.
-   * The cookie is an additional binary data to provide to get the key secret.
+   * Gets the optional cookie corresponding to a given key.
+   * The cookie is a set of key-value pairs to provide to {@link #getKeySecret}.
    *
+   * @param params optional parameters in addition to the key id; or null if none.
+   * @return the key-value pairs; or null if none.
    * @throws java.util.NoSuchElementException if the key is unknown.
    */
-  byte[] getKeyCookie(String keyId) throws IOException;
+  @Nullable
+  Map<String, String> getKeyCookie(String keyId, Map<String, String> params) throws IOException;
 
   /**
    * Gets the encryption key secret corresponding to the provided key id.
+   * Typically, this {@link KeySupplier} holds a cache of key secrets, and may load the key secret if it is
+   * not in the cache or after expiration. In this case, this method may need to get additional data from
+   * the key cookie to load the key secret.
    *
    * @param keyId          Key id which identifies uniquely the encryption key.
-   * @param keyRef         Key internal reference number to provide to the cookie supplier to retrieve the
-   *                       corresponding cookie, if any.
-   * @param cookieSupplier Takes the key reference number as input and supplies an additional binary data
-   *                       cookie required to get the key secret. This supplier may not be called if the
-   *                       key secret is in the transient memory cache. It may return null if there are no
-   *                       cookies.
+   * @param cookieSupplier Takes the key id as input and supplies the optional key cookie key-value pairs
+   *                       that may be needed to retrieve the key secret. It may return null if there are
+   *                       no cookies for the key.
    * @return The key secret bytes. It must be either 16, 24 or 32 bytes long. The caller is not permitted
    * to modify its content. Returns null if the key is known but has no secret bytes, in this case the data
    * is not encrypted.
    * @throws java.util.NoSuchElementException if the key is unknown.
    */
-  byte[] getKeySecret(String keyId, String keyRef, Function<String, byte[]> cookieSupplier) throws IOException;
+  byte[] getKeySecret(String keyId, Function<String, Map<String, String>> cookieSupplier) throws IOException;
 
   /**
-   * Supplies the {@link KeyManager}.
+   * Creates {@link KeySupplier}.
    */
-  interface Supplier {
+  interface Factory {
 
-    /** This supplier may be configured with parameters defined in solrconfig.xml. */
-    void init(NamedList<?> args);
+    /** This factory may be configured with parameters defined in solrconfig.xml. */
+    void init(SolrParams params);
 
-    /** Gets the {@link KeyManager}. */
-    KeyManager getKeyManager();
+    /** Creates a {@link KeySupplier}. */
+    KeySupplier create();
   }
 }

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
@@ -33,6 +33,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.apache.solr.encryption.EncryptionDirectoryFactory.PARAM_KEY_SUPPLIER_FACTORY;
+import static org.apache.solr.encryption.EncryptionDirectoryFactory.PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY;
+import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_1;
+import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_2;
+import static org.apache.solr.encryption.TestingKeySupplier.KEY_SECRET_1;
+import static org.apache.solr.encryption.TestingKeySupplier.KEY_SECRET_2;
+
 /**
  * Tests {@link EncryptionDirectory}.
  * <p>
@@ -51,7 +58,8 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    System.setProperty(EncryptionDirectoryFactory.PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY, MockFactory.class.getName());
+    System.setProperty(PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY, MockFactory.class.getName());
+    System.setProperty("solr." + PARAM_KEY_SUPPLIER_FACTORY, TestingKeySupplier.Factory.class.getName());
     TestUtil.setInstallDirProperty();
     cluster = new MiniSolrCloudCluster.Builder(1, createTempDir())
       .addConfig("config", TestUtil.getConfigPath("collection1"))
@@ -60,7 +68,8 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    System.clearProperty(EncryptionDirectoryFactory.PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY);
+    System.clearProperty(PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY);
+    System.clearProperty("solr." + PARAM_KEY_SUPPLIER_FACTORY);
     cluster.shutdown();
   }
 
@@ -77,7 +86,9 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
   @Override
   public void tearDown() throws Exception {
-    mockDir.clearMockValues();
+    if (mockDir != null) {
+      mockDir.clearMockValues();
+    }
     CollectionAdminRequest.deleteCollection(collectionName).process(solrClient);
     super.tearDown();
   }
@@ -92,7 +103,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
   /**
    * Starts from an empty index, indexes two documents in two segments, then encrypt the index
-   * with {@link TestingKeyManager#KEY_ID_1}. The resulting encrypted index is composed of one segment.
+   * with {@link TestingKeySupplier#KEY_ID_1}. The resulting encrypted index is composed of one segment.
    */
   private void indexAndEncryptOneSegment() throws Exception {
     // Start with no key ids defined in the latest commit metadata.
@@ -108,7 +119,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     // Set the encryption key id in the commit user data,
     // and run an optimized commit to rewrite the index, now encrypted.
-    mockDir.setKeysInCommitUserData(TestingKeyManager.KEY_ID_1);
+    mockDir.setKeysInCommitUserData(KEY_ID_1);
     solrClient.optimize();
 
     // Verify that without key id, we cannot decrypt the index anymore.
@@ -116,11 +127,11 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
     testUtil.assertCannotReloadCore();
     // Verify that with a wrong key id, we cannot decrypt the index.
     mockDir.forceClearText = false;
-    mockDir.forceKeySecret = TestingKeyManager.KEY_SECRET_2;
+    mockDir.forceKeySecret = KEY_SECRET_2;
     testUtil.assertCannotReloadCore();
     // Verify that with the right key id, we can decrypt the index and search it.
     mockDir.forceKeySecret = null;
-    mockDir.expectedKeySecret = TestingKeyManager.KEY_SECRET_1;
+    mockDir.expectedKeySecret = KEY_SECRET_1;
     testUtil.reloadCore();
     testUtil.assertQueryReturns("weather", 2);
     testUtil.assertQueryReturns("sunny", 1);
@@ -137,14 +148,14 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
   }
 
   /**
-   * Creates an index encrypted with {@link TestingKeyManager#KEY_ID_1} and containing two segments.
+   * Creates an index encrypted with {@link TestingKeySupplier#KEY_ID_1} and containing two segments.
    */
   private void indexAndEncryptTwoSegments() throws Exception {
     // Prepare an encrypted index with one segment.
     indexAndEncryptOneSegment();
 
     // Create 1 new segment with the same encryption key id.
-    mockDir.setKeysInCommitUserData(TestingKeyManager.KEY_ID_1);
+    mockDir.setKeysInCommitUserData(KEY_ID_1);
     testUtil.indexDocsAndCommit("foggy weather");
 
     // Verify that without key id, we cannot decrypt the index.
@@ -152,11 +163,11 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
     testUtil.assertCannotReloadCore();
     // Verify that with a wrong key id, we cannot decrypt the index.
     mockDir.forceClearText = false;
-    mockDir.forceKeySecret = TestingKeyManager.KEY_SECRET_2;
+    mockDir.forceKeySecret = KEY_SECRET_2;
     testUtil.assertCannotReloadCore();
     // Verify that with the right key id, we can decrypt the index and search it.
     mockDir.forceKeySecret = null;
-    mockDir.expectedKeySecret = TestingKeyManager.KEY_SECRET_1;
+    mockDir.expectedKeySecret = KEY_SECRET_1;
     testUtil.reloadCore();
     testUtil.assertQueryReturns("weather", 3);
     testUtil.assertQueryReturns("sunny", 1);
@@ -173,7 +184,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     // Set the new encryption key id in the commit user data,
     // and run an optimized commit to rewrite the index, now encrypted with the new key.
-    mockDir.setKeysInCommitUserData(TestingKeyManager.KEY_ID_1, TestingKeyManager.KEY_ID_2);
+    mockDir.setKeysInCommitUserData(KEY_ID_1, KEY_ID_2);
     solrClient.optimize();
 
     // Verify that without key id, we cannot decrypt the index.
@@ -181,11 +192,11 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
     testUtil.assertCannotReloadCore();
     // Verify that with a wrong key id, we cannot decrypt the index.
     mockDir.forceClearText = false;
-    mockDir.forceKeySecret = TestingKeyManager.KEY_SECRET_1;
+    mockDir.forceKeySecret = KEY_SECRET_1;
     testUtil.assertCannotReloadCore();
     // Verify that with the right key id, we can decrypt the index and search it.
     mockDir.forceKeySecret = null;
-    mockDir.expectedKeySecret = TestingKeyManager.KEY_SECRET_2;
+    mockDir.expectedKeySecret = KEY_SECRET_2;
     testUtil.reloadCore();
     testUtil.assertQueryReturns("weather", 3);
     testUtil.assertQueryReturns("sunny", 1);
@@ -201,7 +212,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     // Remove the active key parameter from the commit user data,
     // and run an optimized commit to rewrite the index, now cleartext with no keys.
-    mockDir.setKeysInCommitUserData(TestingKeyManager.KEY_ID_1, null);
+    mockDir.setKeysInCommitUserData(KEY_ID_1, null);
     solrClient.optimize();
 
     // Verify that without key id, we can reload the index because it is not encrypted.
@@ -215,26 +226,26 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
     @Override
     public EncryptionDirectory create(Directory delegate,
                                       AesCtrEncrypterFactory encrypterFactory,
-                                      KeyManager keyManager) throws IOException {
-      return mockDir = new MockEncryptionDirectory(delegate, encrypterFactory, keyManager);
+                                      KeySupplier keySupplier) throws IOException {
+      return mockDir = new MockEncryptionDirectory(delegate, encrypterFactory, keySupplier);
     }
   }
 
   private static class MockEncryptionDirectory extends EncryptionDirectory {
 
-    final KeyManager keyManager;
+    final KeySupplier keySupplier;
     boolean forceClearText;
     byte[] forceKeySecret;
     byte[] expectedKeySecret;
 
-    MockEncryptionDirectory(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeyManager keyManager)
+    MockEncryptionDirectory(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeySupplier keySupplier)
       throws IOException {
-      super(delegate, encrypterFactory, keyManager);
-      this.keyManager = keyManager;
+      super(delegate, encrypterFactory, keySupplier);
+      this.keySupplier = keySupplier;
     }
 
     void clearMockValues() {
-      commitUserData.data.clear();
+      commitUserData = new CommitUserData(commitUserData.segmentFileName, Map.of());
       forceClearText = false;
       forceKeySecret = null;
       expectedKeySecret = null;
@@ -244,14 +255,15 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
      * Clears the commit user data, then sets the provided key ids. The last key id is the active one.
      */
     void setKeysInCommitUserData(String... keyIds) throws IOException {
-      commitUserData.data.clear();
+      Map<String, String> data = new HashMap<>();
       for (String keyId : keyIds) {
         if (keyId == null) {
-          EncryptionUtil.removeActiveKeyRefFromCommit(commitUserData.data);
+          EncryptionUtil.removeActiveKeyRefFromCommit(data);
         } else {
-          EncryptionUtil.setNewActiveKeyIdInCommit(keyId, keyManager.getKeyCookie(keyId), commitUserData.data);
+          EncryptionUtil.setNewActiveKeyIdInCommit(keyId, keySupplier.getKeyCookie(keyId, null), data);
         }
       }
+      commitUserData = new CommitUserData(commitUserData.segmentFileName, data);
     }
 
     @Override

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 
 import static org.apache.solr.encryption.EncryptionDirectoryFactory.PARAM_KEY_SUPPLIER_FACTORY;
 import static org.apache.solr.encryption.EncryptionDirectoryFactory.PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY;
+import static org.apache.solr.encryption.TestingEncryptionRequestHandler.MOCK_COOKIE_PARAMS;
 import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_1;
 import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_2;
 import static org.apache.solr.encryption.TestingKeySupplier.KEY_SECRET_1;
@@ -260,7 +261,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
         if (keyId == null) {
           EncryptionUtil.removeActiveKeyRefFromCommit(data);
         } else {
-          EncryptionUtil.setNewActiveKeyIdInCommit(keyId, keySupplier.getKeyCookie(keyId, null), data);
+          EncryptionUtil.setNewActiveKeyIdInCommit(keyId, keySupplier.getKeyCookie(keyId, MOCK_COOKIE_PARAMS), data);
         }
       }
       commitUserData = new CommitUserData(commitUserData.segmentFileName, data);

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionHeavyLoadTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionHeavyLoadTest.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import static org.apache.solr.encryption.EncryptionRequestHandler.*;
-import static org.apache.solr.encryption.TestingKeyManager.*;
+import static org.apache.solr.encryption.TestingKeySupplier.*;
 
 /**
  * Tests the encryption handler under heavy concurrent load test.

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionMergePolicyFactoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionMergePolicyFactoryTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.solr.encryption.TestingEncryptionRequestHandler.MOCK_COOKIE_PARAMS;
 import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_1;
 import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_2;
 
@@ -129,7 +130,7 @@ public class EncryptionMergePolicyFactoryTest extends LuceneTestCase {
   private void commit(IndexWriter writer, KeySupplier keySupplier, String... keyIds) throws IOException {
     Map<String, String> commitData = new HashMap<>();
     for (String keyId : keyIds) {
-      EncryptionUtil.setNewActiveKeyIdInCommit(keyId, keySupplier.getKeyCookie(keyId, null), commitData);
+      EncryptionUtil.setNewActiveKeyIdInCommit(keyId, keySupplier.getKeyCookie(keyId, MOCK_COOKIE_PARAMS), commitData);
     }
     writer.setLiveCommitData(commitData.entrySet());
     writer.commit();

--- a/encryption/src/test/java/org/apache/solr/encryption/TestingEncryptionRequestHandler.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/TestingEncryptionRequestHandler.java
@@ -14,36 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id 'java'
-}
+package org.apache.solr.encryption;
 
-description = 'Index Encryption At-Rest package'
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
 
-repositories {
-    mavenCentral()
-}
+import java.util.Map;
 
-configurations {
-    provided
-}
+public class TestingEncryptionRequestHandler extends EncryptionRequestHandler {
 
-sourceSets {
-    main { compileClasspath += configurations.provided }
-}
+  public static final Map<String, String> MOCK_COOKIE_PARAMS = Map.of("testParam", "testValue");
 
-dependencies {
-    implementation 'org.apache.solr:solr-core:9.2.1'
-    implementation 'org.apache.lucene:lucene-core:9.5.0'
-    implementation 'com.google.code.findbugs:jsr305:3.0.2'
-
-    // Remove when removing DirectUpdateHandler2Copy.
-    implementation 'javax.servlet:javax.servlet-api:3.1.0'
-
-    testImplementation 'org.apache.solr:solr-test-framework:9.2.1'
-    testImplementation 'org.apache.lucene:lucene-test-framework:9.5.0'
-}
-
-test {
-    jvmArgs '-Djava.security.egd=file:/dev/./urandom'
+  @Override
+  protected Map<String, String> buildGetCookieParams(SolrQueryRequest req, SolrQueryResponse rsp) {
+    return MOCK_COOKIE_PARAMS;
+  }
 }

--- a/encryption/src/test/resources/configs/collection1/solrconfig.xml
+++ b/encryption/src/test/resources/configs/collection1/solrconfig.xml
@@ -50,7 +50,7 @@
   </requestHandler>
 
   <!-- Encryption handler -->
-  <requestHandler name="/admin/encrypt" class="org.apache.solr.encryption.EncryptionRequestHandler"/>
+  <requestHandler name="/admin/encrypt" class="org.apache.solr.encryption.TestingEncryptionRequestHandler"/>
 
   <indexConfig>
     <mergeScheduler class="${solr.mscheduler:org.apache.lucene.index.ConcurrentMergeScheduler}"/>

--- a/encryption/src/test/resources/configs/collection1/solrconfig.xml
+++ b/encryption/src/test/resources/configs/collection1/solrconfig.xml
@@ -25,7 +25,7 @@
 
   <directoryFactory name="DirectoryFactory"
                     class="org.apache.solr.encryption.EncryptionDirectoryFactory">
-    <str name="keyManagerSupplier">org.apache.solr.encryption.TestingKeyManager$Supplier</str>
+    <str name="keySupplierFactory">org.apache.solr.encryption.TestingKeySupplier$Factory</str>
     <str name="encrypterFactory">org.apache.solr.encryption.crypto.LightAesCtrEncrypter$Factory</str>
   </directoryFactory>
 


### PR DESCRIPTION
Additional parameters can be provided to the EncryptionRequestHandler in the SolrQueryRequest. The handler can be extended to send the relevant parameters to the KeySupplier when retrieving the key cookie (generic key-value pairs).