### PR TITLE
Fix EncryptionMergePolicy to reencrypt each segment separately.

### DIFF
--- a/ENCRYPTION.md
+++ b/ENCRYPTION.md
@@ -33,11 +33,6 @@ on performance: expect -20% on most queries, -60% on multi-term queries.
 - Currently, this encryption module does not encrypt TLogs.
 That means the update requests data that are stored in these logs are cleartext.
 
-- Currently, EncryptionMergePolicy does not fully work, so it is disabled.
-That means a call to /admin/encrypt to re-encrypt a Solr Core index will trigger
-an optimized commit which merges all index segments into one. This works but is
-heavyweight.
-
 ## Installing and Configuring the Encryption Plug-In
 
 1. Configure the sharedLib directory in solr.xml (e.g. sharedLIb=lib) and place
@@ -66,8 +61,7 @@ the Encryption plug-in jar file into the specified folder.
         <str name="encrypterFactory">org.apache.solr.encryption.crypto.CipherAesCtrEncrypter$Factory</str>
     </directoryFactory>
 
-    <updateHandler class="org.apache.solr.encryption.EncryptionUpdateHandler">
-    </updateHandler>
+    <updateHandler class="org.apache.solr.encryption.EncryptionUpdateHandler"/>
 
     <requestHandler name="/admin/encrypt" class="org.apache.solr.encryption.EncryptionRequestHandler"/>
 

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionUtil.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionUtil.java
@@ -70,7 +70,7 @@ public class EncryptionUtil {
    * Number of inactive key ids to keep when clearing the old inactive key ids.
    * @see #clearOldInactiveKeyIdsFromCommit
    */
-  private static final int INACTIVE_KEY_IDS_TO_KEEP = 10;
+  private static final int INACTIVE_KEY_IDS_TO_KEEP = 15;
 
   /**
    * Sets the new active encryption key id, and its optional cookie in the provided commit user data.

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionHeavyLoadTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionHeavyLoadTest.java
@@ -62,7 +62,7 @@ import static org.apache.solr.encryption.TestingKeySupplier.*;
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 public class EncryptionHeavyLoadTest extends SolrCloudTestCase {
 
-  // Change the test duration manually to run longer, e.g. 3 minutes.
+  // Change the test duration manually to run longer, e.g. 20 minutes.
   private static final long TEST_DURATION_MS = TimeUnit.SECONDS.toMillis(10);
   private static final int RANDOM_DELAY_BETWEEN_INDEXING_BATCHES_MS = 50;
   private static final int RANDOM_NUM_DOCS_PER_BATCH = 200;


### PR DESCRIPTION
Now EncryptionHeavyLoadTest passes the 20min run bar.

This means we can enable EncryptionMergePolicy which re-encrypts each index segment individually. This is way faster than an optimized merge into a single segment as previously:
- No time spent to merge all segments into one.
- We leverage Lucene concurrent merge: segments are re-encrypted by parallel threads from the mergers pool.