### PR TITLE
Documents lost in Consumer during target Solr restart.

### DIFF
--- a/crossdc-consumer/build.gradle
+++ b/crossdc-consumer/build.gradle
@@ -40,14 +40,11 @@ dependencies {
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.41.v20210516'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
     testImplementation project(path: ':crossdc-commons')
-    testImplementation project(path: ':crossdc-commons')
     runtimeOnly ('com.google.protobuf:protobuf-java-util:3.22.2')
     runtimeOnly ('commons-codec:commons-codec:1.15')
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation('org.mockito:mockito-inline:5.2.0')
-
-    testImplementation  project(':crossdc-producer')
 
     testImplementation group: 'org.apache.solr', name: 'solr-core', version: '8.11.2', {
         exclude group: "org.apache.logging.log4j", module: "*"

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
@@ -183,7 +183,8 @@ import java.util.Properties;
   public void testRetryQueue() throws Exception {
     Path zkDir = zkTestServer2.getZkDir();
     int zkPort = zkTestServer2.getPort();
-    zkTestServer2.shutdown();
+    solrCluster2.getJettySolrRunner(0).stop();
+    //zkTestServer2.shutdown();
 
     CloudSolrClient client = solrCluster1.getSolrClient();
     SolrInputDocument doc = new SolrInputDocument();
@@ -208,10 +209,12 @@ import java.util.Properties;
 
     System.out.println("Sent producer record");
 
-    Thread.sleep(5000);
+    Thread.sleep(30000);
 
-    zkTestServer2 = new ZkTestServer(zkDir, zkPort);
-    zkTestServer2.run(false);
+    //zkTestServer2 = new ZkTestServer(zkDir, zkPort);
+    //zkTestServer2.run(false);
+    solrCluster2.getJettySolrRunner(0).start();
+    Thread.sleep(10000);
 
     QueryResponse results = null;
     boolean foundUpdates = false;


### PR DESCRIPTION
This modified test illustrates a scenario when target Solr node(s) go missing (for example due to a crash, a forced restart, or connectivity issues) BUT at the same time the Zookeeper remains online.

The test fails because it looks like some of the documents are lost by the Consumer, even though the `failed_resubmit` code path should resubmit them back to Kafka and they should be picked up later when Solr is back online.