### PR TITLE
Dead letter queue fix

### DIFF
--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/MirroredSolrRequest.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/MirroredSolrRequest.java
@@ -172,7 +172,11 @@ public class MirroredSolrRequest {
     }
 
     public MirroredSolrRequest(final Type type, final SolrRequest solrRequest) {
-        this(type, 1, solrRequest, TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis()));
+        this(type, 1, solrRequest);
+    }
+
+    public MirroredSolrRequest(final Type type, final int attempt, final SolrRequest solrRequest) {
+        this(type, attempt, solrRequest, TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis()));
     }
 
     public MirroredSolrRequest(final Type type, final int attempt, final SolrRequest solrRequest, final long submitTimeNanos) {

--- a/crossdc-consumer/src/test/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumerTest.java
+++ b/crossdc-consumer/src/test/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumerTest.java
@@ -196,8 +196,7 @@ public class KafkaCrossDcConsumerTest {
         consumer.kafkaMirroringSink = mockKafkaMirroringSink;
 
         // Call the method to test
-        ConsumerRecord<String, MirroredSolrRequest> record = createSampleConsumerRecord();
-        consumer.processResult(record, failedResubmitResult);
+        consumer.processResult(failedResubmitResult);
 
         // Verify that the KafkaMirroringSink.submit() method was called
         verify(consumer.kafkaMirroringSink, times(1)).submit(request);


### PR DESCRIPTION
There was a problem with sending message to dead letter queue when the number of attempts is greater than specified limit. It was not possible to set attempt value in `MirroredSolrRequest` constructor so it was always specified to `1`. `record` is no longer needed in `processResult` method because we should use `attempt` value from the result variable (copied from lastRecord and incremented if it has failed).