### PR TITLE
Upgrade Kafka to 3.5.1

### DIFF
--- a/crossdc-commons/build.gradle
+++ b/crossdc-commons/build.gradle
@@ -34,11 +34,8 @@ sourceSets {
 }
 
 dependencies {
-    provided 'org.apache.solr:solr-solrj:8.11.2', {
-        exclude group: "org.apache.logging.log4j", module: "*"
-        exclude group: "org.slf4j", module: "*"
-    }
-    implementation 'org.apache.kafka:kafka-clients:2.8.1'
+    provided 'org.apache.solr:solr-solrj:8.11.2'
+    implementation 'org.apache.kafka:kafka-clients:3.5.1'
     implementation 'com.google.guava:guava:14.0'
     testImplementation 'org.slf4j:slf4j-api:2.0.5'
     testImplementation 'org.hamcrest:hamcrest:2.2'
@@ -46,16 +43,11 @@ dependencies {
     testImplementation('org.mockito:mockito-inline:5.2.0')
 
     testImplementation group: 'org.apache.solr', name: 'solr-core', version: '8.11.2', {
-        exclude group: "org.apache.logging.log4j", module: "*"
-        exclude group: "org.slf4j", module: "*"
         exclude group: "org.eclipse.jetty", module: "jetty-http"
         exclude group: "org.eclipse.jetty", module: "jetty-server"
         exclude group: "org.eclipse.jetty", module: "jetty-servlet"
     }
-    testImplementation group: 'org.apache.solr', name: 'solr-test-framework', version: '8.11.2', {
-        exclude group: "org.apache.logging.log4j", module: "*"
-        exclude group: "org.slf4j", module: "*"
-    }
+    testImplementation group: 'org.apache.solr', name: 'solr-test-framework', version: '8.11.2'
 }
 
 jar.enabled = false

--- a/crossdc-consumer/build.gradle
+++ b/crossdc-consumer/build.gradle
@@ -60,10 +60,10 @@ dependencies {
         exclude group: "org.apache.logging.log4j", module: "*"
         exclude group: "org.slf4j", module: "*"
     }
-    implementation 'org.apache.kafka:kafka_2.13:2.8.1'
-    implementation 'org.apache.kafka:kafka-streams:2.8.1'
-    testImplementation 'org.apache.kafka:kafka_2.13:2.8.1:test'
-    testImplementation 'org.apache.kafka:kafka-streams:2.8.1:test'
+    implementation 'org.apache.kafka:kafka_2.13:3.5.1'
+    implementation 'org.apache.kafka:kafka-streams:3.5.1'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.5.1:test'
+    testImplementation 'org.apache.kafka:kafka-streams:3.5.1:test'
 }
 
 test {

--- a/crossdc-producer/build.gradle
+++ b/crossdc-producer/build.gradle
@@ -45,12 +45,13 @@ dependencies {
     testImplementation group: 'org.apache.solr', name: 'solr-core', version: '8.11.2'
     testImplementation group: 'org.apache.solr', name: 'solr-test-framework', version: '8.11.2'
 
-    testImplementation 'org.apache.kafka:kafka_2.13:2.8.1'
-    testImplementation 'org.apache.kafka:kafka-streams:2.8.1'
-    testImplementation 'org.apache.kafka:kafka_2.13:2.8.1:test'
-    testImplementation 'org.apache.kafka:kafka-streams:2.8.1:test'
+    testImplementation 'org.apache.kafka:kafka-clients:3.5.1:test'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.5.1'
+    testImplementation 'org.apache.kafka:kafka-streams:3.5.1'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.5.1:test'
+    testImplementation 'org.apache.kafka:kafka-streams:3.5.1:test'
+    testImplementation 'org.apache.kafka:kafka-server-common:3.5.1:test'
 
-    testImplementation 'org.apache.kafka:kafka-clients:2.8.1:test'
 }
 
 jar.enabled = false

--- a/crossdc-producer/src/main/java/org/apache/solr/handler/admin/MirroringConfigSetsHandler.java
+++ b/crossdc-producer/src/main/java/org/apache/solr/handler/admin/MirroringConfigSetsHandler.java
@@ -64,6 +64,7 @@ public class MirroringConfigSetsHandler extends ConfigSetsHandler {
           zkClient = coreContainer.getZkController().getZkClient();
         }
         ConfUtil.fillProperties(zkClient, properties);
+        ConfUtil.verifyProperties(properties);
         KafkaCrossDcConf conf = new KafkaCrossDcConf(properties);
         this.sink = new KafkaMirroringSink(conf);
       } catch (Exception e) {

--- a/crossdc-producer/src/test/java/org/apache/solr/handler/admin/MirroringConfigSetsHandlerTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/handler/admin/MirroringConfigSetsHandlerTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.solr.handler.admin;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import org.apache.commons.io.IOUtils;
+import org.apache.lucene.util.QuickPatchThreadsFilter;
+import org.apache.solr.SolrIgnoredThreadsFilter;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.cloud.ZkController;
-import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ConfigSetParams;
@@ -30,15 +32,15 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.ContentStreamBase;
 import org.apache.solr.core.CoreContainer;
+import org.apache.solr.core.NodeConfig;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrXmlConfig;
-import org.apache.solr.crossdc.common.CrossDcConf;
+import org.apache.solr.crossdc.SolrKafkaTestsIgnoredThreadsFilter;
 import org.apache.solr.crossdc.common.KafkaMirroringSink;
 import org.apache.solr.crossdc.common.MirroredSolrRequest;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,9 +49,11 @@ import org.mockito.Mockito;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
+@ThreadLeakFilters(defaultFilters = true, filters = { SolrIgnoredThreadsFilter.class,
+    QuickPatchThreadsFilter.class, SolrKafkaTestsIgnoredThreadsFilter.class })
+@ThreadLeakLingering(linger = 5000)
 public class MirroringConfigSetsHandlerTest extends SolrTestCaseJ4 {
 
     private KafkaMirroringSink sink = Mockito.mock(KafkaMirroringSink.class);
@@ -140,12 +144,7 @@ public class MirroringConfigSetsHandlerTest extends SolrTestCaseJ4 {
     public void testCoreContainerInit() throws Exception {
         Path home = createTempDir();
         String solrXml = IOUtils.resourceToString("/mirroring-solr.xml", StandardCharsets.UTF_8);
-        CoreContainer cores = new CoreContainer(SolrXmlConfig.fromString(home, solrXml));
-        try {
-            cores.load();
-            assertTrue(cores.getConfigSetsHandler() instanceof MirroringConfigSetsHandler);
-        } finally {
-            cores.shutdown();
-        }
+        NodeConfig nodeConfig = SolrXmlConfig.fromString(home, solrXml);
+        assertEquals(MirroringConfigSetsHandler.class.getName(), nodeConfig.getConfigSetsHandlerClass());
     }
 }


### PR DESCRIPTION
The project uses version 2.8.1. I propose to upgrade it to a recent version of 3.x (3.5.1) to benefit from many improvements, especially important for the cross-dc mirroring use case (Kafka Connect, MirrorMaker 2, stronger delivery guarantees, etc).