### PR TITLE
Fix KafkaCrossDcConsumer NPE, add unit test.

### DIFF
--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
@@ -227,7 +227,9 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
                 log.trace("SolrParams have changed, starting new UpdateRequest, params={}", params);
               }
               // send previous batch, if any
-              sendBatch(updateReqBatch, type, lastRecord, workUnit);
+              if (updateReqBatch != null) {
+                sendBatch(updateReqBatch, type, lastRecord, workUnit);
+              }
               updateReqBatch = new UpdateRequest();
               lastUpdateParamsAsNamedList = null;
               workUnit = new PartitionManager.WorkUnit(partition);


### PR DESCRIPTION
When the first request is an ADMIN request and only then an UPDATE request is sent at this point the updateReqBatch is still null and sendBatch causes NPE.