### PR TITLE
RetryQueueIntegrationTest failures

### DIFF
--- a/crossdc-producer/build.gradle
+++ b/crossdc-producer/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation group: 'org.apache.solr', name: 'solr-core', version: '8.11.2'
     testImplementation group: 'org.apache.solr', name: 'solr-test-framework', version: '8.11.2'
 
+    testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.9'
     testImplementation 'org.apache.kafka:kafka-clients:3.5.1:test'
     testImplementation 'org.apache.kafka:kafka_2.13:3.5.1'
     testImplementation 'org.apache.kafka:kafka-streams:3.5.1'

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
@@ -114,6 +114,7 @@ import java.util.Properties;
     properties.put(KafkaCrossDcConf.ZK_CONNECT_STRING, solrCluster2.getZkServer().getZkAddress());
     properties.put(KafkaCrossDcConf.TOPIC_NAME, TOPIC);
     properties.put(KafkaCrossDcConf.GROUP_ID, "group1");
+    properties.put(KafkaCrossDcConf.MAX_ATTEMPTS, 100);
     consumer.start(properties);
   }
 
@@ -224,7 +225,7 @@ import java.util.Properties;
       }
     }
 
-    assertTrue("results=" + results, foundUpdates);
+    assertTrue("expected updates not found, results=" + results, foundUpdates);
     System.out.println("Rest: " + results);
 
   }
@@ -278,7 +279,7 @@ import java.util.Properties;
       }
     }
 
-    assertTrue("results=" + results, foundUpdates);
+    assertTrue("expected updates not found, results=" + results, foundUpdates);
     System.out.println("Rest: " + results);
 
   }


### PR DESCRIPTION
This started failing after recent changes. It turns out that the time between Solr shutdown and restart was sometimes long enough to exhaust the default maxAttempts and the messages were sent to DLQ. The irony is that the test incorrectly expected infinite attempts, and it started failing after PR82 which fixed the maxAttempts functionality.