### PR TITLE
Add endpoint to expose consumer metrics.

### DIFF
--- a/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/IQueueHandler.java
+++ b/crossdc-commons/src/main/java/org/apache/solr/crossdc/common/IQueueHandler.java
@@ -37,24 +37,24 @@ public interface IQueueHandler<T> {
     class Result<T> {
         private final ResultStatus _status;
         private final Throwable _throwable;
-        private final T _newItem;
+        private final T _item;
 
         public Result(final ResultStatus status) {
             _status = status;
             _throwable = null;
-            _newItem = null;
+            _item = null;
         }
 
         public Result(final ResultStatus status, final Throwable throwable) {
             _status = status;
             _throwable = throwable;
-            _newItem = null;
+            _item = null;
         }
 
         public Result(final ResultStatus status, final Throwable throwable, final T newItem) {
             _status = status;
             _throwable = throwable;
-            _newItem = newItem;
+            _item = newItem;
         }
 
         public ResultStatus status() {
@@ -65,8 +65,8 @@ public interface IQueueHandler<T> {
             return _throwable;
         }
 
-        public T newItem() {
-            return _newItem;
+        public T getItem() {
+            return _item;
         }
     }
 

--- a/crossdc-consumer/build.gradle
+++ b/crossdc-consumer/build.gradle
@@ -39,8 +39,7 @@ dependencies {
     implementation 'org.eclipse.jetty:jetty-server:9.4.41.v20210516'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0' // log4j impl can use StackLocatorUtil which is in the api jar
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.41.v20210516'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
-    testImplementation project(path: ':crossdc-commons')
+    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.9'
     testImplementation project(path: ':crossdc-commons')
     runtimeOnly ('com.google.protobuf:protobuf-java-util:3.22.2')
     runtimeOnly ('commons-codec:commons-codec:1.15')

--- a/crossdc-consumer/build.gradle
+++ b/crossdc-consumer/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(path: ':crossdc-commons', configuration: 'shadow')
 
     implementation 'io.dropwizard.metrics:metrics-core:4.2.17'
+    implementation 'io.dropwizard.metrics:metrics-servlets:4.2.17'
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'org.eclipse.jetty:jetty-http:9.4.41.v20210516'
     implementation 'org.eclipse.jetty:jetty-server:9.4.41.v20210516'

--- a/crossdc-consumer/build.gradle
+++ b/crossdc-consumer/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.eclipse.jetty:jetty-server:9.4.41.v20210516'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0' // log4j impl can use StackLocatorUtil which is in the api jar
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.41.v20210516'
+    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.9'
     testImplementation project(path: ':crossdc-commons')
     runtimeOnly ('com.google.protobuf:protobuf-java-util:3.22.2')

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
@@ -37,7 +37,7 @@ import java.util.concurrent.*;
 public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final MetricRegistry metrics = SharedMetricRegistries.getOrCreate("metrics");
+  private final MetricRegistry metrics = SharedMetricRegistries.getOrCreate(Consumer.METRICS_REGISTRY);
 
   private final KafkaConsumer<String,MirroredSolrRequest> kafkaConsumer;
   private final CountDownLatch startLatch;

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
@@ -272,7 +272,6 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
             } else {
               // non-update requests should be sent immediately
               sendBatch(req.getSolrRequest(), type, lastRecord, workUnit);
-              metrics.counter(type.name()).inc();
             }
           }
 

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumer.java
@@ -216,6 +216,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
             MirroredSolrRequest req = requestRecord.value();
             SolrRequest solrReq = req.getSolrRequest();
             MirroredSolrRequest.Type type = req.getType();
+            metrics.counter(MetricRegistry.name(type.name(), "input")).inc();
             ModifiableSolrParams params = new ModifiableSolrParams(solrReq.getParams());
             if (log.isTraceEnabled()) {
               log.trace("-- picked type={}, params={}", req.getType(), params);
@@ -376,7 +377,7 @@ public class KafkaCrossDcConsumer extends Consumer.CrossDcConsumer {
         if (log.isTraceEnabled()) {
           log.trace("result=nothandled_shutdown");
         }
-        metrics.counter("nothandled_shutdown").inc();
+        metrics.counter(MetricRegistry.name(type.name(), "nothandled_shutdown")).inc();
       case FAILED_RETRY:
         log.error("Unexpected response while processing request. We never expect {}.", result.status().toString());
         metrics.counter(MetricRegistry.name(type.name(), "failed-retry")).inc();

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessor.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessor.java
@@ -351,7 +351,7 @@ public class SolrMessageProcessor extends MessageProcessor implements IQueueHand
 
     private void backoffIfNeeded(Result<MirroredSolrRequest> result) {
         if (result.status().equals(ResultStatus.FAILED_RESUBMIT)) {
-            final long backoffMs = getResubmitBackoffPolicy().getBackoffTimeMs(result.newItem());
+            final long backoffMs = getResubmitBackoffPolicy().getBackoffTimeMs(result.getItem());
             if (backoffMs > 0L) {
                 try {
                     Thread.sleep(backoffMs);

--- a/crossdc-consumer/src/main/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessor.java
+++ b/crossdc-consumer/src/main/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessor.java
@@ -285,7 +285,7 @@ public class SolrMessageProcessor extends MessageProcessor implements IQueueHand
         if (mirroredSolrRequest.getAttempt() == 1) {
             final long latency = System.currentTimeMillis() - TimeUnit.NANOSECONDS.toMillis(mirroredSolrRequest.getSubmitTimeNanos());
             log.debug("First attempt latency = {}", latency);
-            metrics.timer(MetricRegistry.name(mirroredSolrRequest.getType().name(), "latency")).update(latency, TimeUnit.MILLISECONDS);
+            metrics.timer(MetricRegistry.name(mirroredSolrRequest.getType().name(), "outputLatency")).update(latency, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/crossdc-consumer/src/test/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumerTest.java
+++ b/crossdc-consumer/src/test/java/org/apache/solr/crossdc/consumer/KafkaCrossDcConsumerTest.java
@@ -196,7 +196,7 @@ public class KafkaCrossDcConsumerTest {
         consumer.kafkaMirroringSink = mockKafkaMirroringSink;
 
         // Call the method to test
-        consumer.processResult(failedResubmitResult);
+        consumer.processResult(MirroredSolrRequest.Type.UPDATE, failedResubmitResult);
 
         // Verify that the KafkaMirroringSink.submit() method was called
         verify(consumer.kafkaMirroringSink, times(1)).submit(request);

--- a/crossdc-consumer/src/test/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessorTest.java
+++ b/crossdc-consumer/src/test/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessorTest.java
@@ -38,6 +38,7 @@ public class SolrMessageProcessorTest {
     public void handleItemWithFailedResultNoRetry() throws SolrServerException, IOException {
         MirroredSolrRequest mirroredSolrRequest = mock(MirroredSolrRequest.class);
         SolrRequest solrRequest = mock(SolrRequest.class);
+        when(mirroredSolrRequest.getType()).thenReturn(MirroredSolrRequest.Type.UPDATE);
         when(mirroredSolrRequest.getSolrRequest()).thenReturn(solrRequest);
 
         SolrResponseBase solrResponseBase = mock(SolrResponseBase.class);
@@ -58,6 +59,7 @@ public class SolrMessageProcessorTest {
     public void handleItemWithFailedResultResubmit() throws SolrServerException, IOException {
         MirroredSolrRequest mirroredSolrRequest = mock(MirroredSolrRequest.class);
         SolrRequest solrRequest = mock(SolrRequest.class);
+        when(mirroredSolrRequest.getType()).thenReturn(MirroredSolrRequest.Type.UPDATE);
         when(mirroredSolrRequest.getSolrRequest()).thenReturn(solrRequest);
         when(solrRequest.process(client))
                 .thenThrow(new SolrException(ErrorCode.SERVER_ERROR, "Server error"));
@@ -77,6 +79,7 @@ public class SolrMessageProcessorTest {
         SolrRequest solrRequest = mock(SolrRequest.class);
         SolrResponseBase solrResponse = mock(SolrResponseBase.class);
 
+        when(mirroredSolrRequest.getType()).thenReturn(MirroredSolrRequest.Type.UPDATE);
         when(mirroredSolrRequest.getSolrRequest()).thenReturn(solrRequest);
         when(solrRequest.process(client)).thenReturn(solrResponse);
         when(solrResponse.getStatus()).thenReturn(0);
@@ -96,6 +99,7 @@ public class SolrMessageProcessorTest {
         SolrRequest solrRequest = mock(SolrRequest.class);
         SolrResponseBase solrResponse = mock(SolrResponseBase.class);
 
+        when(mirroredSolrRequest.getType()).thenReturn(MirroredSolrRequest.Type.UPDATE);
         when(mirroredSolrRequest.getSolrRequest()).thenReturn(solrRequest);
         when(solrRequest.process(client)).thenReturn(solrResponse);
         when(solrResponse.getStatus()).thenReturn(0);

--- a/crossdc-consumer/src/test/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessorTest.java
+++ b/crossdc-consumer/src/test/java/org/apache/solr/crossdc/messageprocessor/SolrMessageProcessorTest.java
@@ -65,7 +65,7 @@ public class SolrMessageProcessorTest {
         IQueueHandler.Result<MirroredSolrRequest> result = solrMessageProcessor.handleItem(mirroredSolrRequest);
 
         assertEquals(IQueueHandler.ResultStatus.FAILED_RESUBMIT, result.status());
-        assertEquals(mirroredSolrRequest, result.newItem());
+        assertEquals(mirroredSolrRequest, result.getItem());
     }
 
     /**
@@ -84,7 +84,7 @@ public class SolrMessageProcessorTest {
         IQueueHandler.Result<MirroredSolrRequest> result = solrMessageProcessor.handleItem(mirroredSolrRequest);
 
         assertEquals(IQueueHandler.ResultStatus.HANDLED, result.status());
-        assertNull(result.newItem());
+        assertNull(result.getItem());
     }
 
     /**

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/DeleteByQueryToIdTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/DeleteByQueryToIdTest.java
@@ -41,7 +41,7 @@ import java.util.Properties;
   protected static volatile MiniSolrCloudCluster solrCluster1;
   protected static volatile MiniSolrCloudCluster solrCluster2;
 
-  protected static volatile Consumer consumer = new Consumer();
+  protected static volatile Consumer consumer;
 
   private static String TOPIC = "topic1";
 
@@ -50,6 +50,8 @@ import java.util.Properties;
   @BeforeClass
   public static void beforeSolrAndKafkaIntegrationTest() throws Exception {
 
+    System.setProperty(KafkaCrossDcConf.PORT, "-1");
+    consumer = new Consumer();
     System.setProperty("solr.crossdc.dbq_rows", "1");
 
     Properties config = new Properties();

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/RetryQueueIntegrationTest.java
@@ -48,7 +48,7 @@ import java.util.Properties;
   protected static volatile MiniSolrCloudCluster solrCluster1;
   protected static volatile MiniSolrCloudCluster solrCluster2;
 
-  protected static volatile Consumer consumer = new Consumer();
+  protected static volatile Consumer consumer;
 
   private static String TOPIC = "topic1";
 
@@ -60,6 +60,9 @@ import java.util.Properties;
 
   @BeforeClass
   public static void beforeRetryQueueIntegrationTestTest() throws Exception {
+
+    System.setProperty(KafkaCrossDcConf.PORT, "-1");
+    consumer = new Consumer();
 
     Properties config = new Properties();
     config.put("unclean.leader.election.enable", "true");

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaIntegrationTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.solr.crossdc.common.KafkaCrossDcConf.DEFAULT_MAX_REQUEST_SIZE;
 import static org.apache.solr.crossdc.common.KafkaCrossDcConf.INDEX_UNMIRRORABLE_DOCS;
+import static org.apache.solr.crossdc.common.KafkaCrossDcConf.PORT;
 import static org.mockito.Mockito.spy;
 
 @ThreadLeakFilters(defaultFilters = true, filters = { SolrIgnoredThreadsFilter.class,
@@ -80,6 +81,7 @@ import static org.mockito.Mockito.spy;
     Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
       log.error("Uncaught exception in thread " + t, e);
     });
+    System.setProperty(PORT, "-1");
     consumer = new Consumer();
     Properties config = new Properties();
     //config.put("unclean.leader.election.enable", "true");

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaMultiCollectionIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaMultiCollectionIntegrationTest.java
@@ -69,6 +69,7 @@ import static org.apache.solr.crossdc.common.KafkaCrossDcConf.INDEX_UNMIRRORABLE
 
   @Before
   public void beforeSolrAndKafkaIntegrationTest() throws Exception {
+    System.setProperty(KafkaCrossDcConf.PORT, "-1");
     consumer = new Consumer();
     Properties config = new Properties();
     //config.put("unclean.leader.election.enable", "true");

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaReindexTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/SolrAndKafkaReindexTest.java
@@ -42,7 +42,7 @@ import java.util.*;
   protected static volatile MiniSolrCloudCluster solrCluster1;
   protected static volatile MiniSolrCloudCluster solrCluster2;
 
-  protected static volatile Consumer consumer = new Consumer();
+  protected static volatile Consumer consumer;
 
   private static String TOPIC = "topic1";
 
@@ -50,6 +50,8 @@ import java.util.*;
 
   @BeforeClass
   public static void beforeSolrAndKafkaIntegrationTest() throws Exception {
+    System.setProperty(KafkaCrossDcConf.PORT, "-1");
+    consumer = new Consumer();
 
     Properties config = new Properties();
     config.put("unclean.leader.election.enable", "true");

--- a/crossdc-producer/src/test/java/org/apache/solr/crossdc/ZkConfigIntegrationTest.java
+++ b/crossdc-producer/src/test/java/org/apache/solr/crossdc/ZkConfigIntegrationTest.java
@@ -43,8 +43,8 @@ import java.util.Properties;
   protected static volatile MiniSolrCloudCluster solrCluster1;
   protected static volatile MiniSolrCloudCluster solrCluster2;
 
-  protected static volatile Consumer consumer1 = new Consumer();
-  protected static volatile Consumer consumer2 = new Consumer();
+  protected static volatile Consumer consumer1;
+  protected static volatile Consumer consumer2;
 
   private static String TOPIC1 = "topicSrc";
   private static String TOPIC2 = "topicDst";
@@ -53,7 +53,9 @@ import java.util.Properties;
 
   @BeforeClass
   public static void beforeSolrAndKafkaIntegrationTest() throws Exception {
-
+    System.setProperty(KafkaCrossDcConf.PORT, "-1");
+    consumer1 = new Consumer();
+    consumer2 = new Consumer();
     Properties config = new Properties();
     config.put("unclean.leader.election.enable", "true");
     config.put("enable.partition.eof", "false");


### PR DESCRIPTION
This PR adds a Jetty-based server + servlet to expose the collected consumer metrics.

I added two endpoints:

* `/threads` to view a thread dump
* `/metrics` to view the collected metrics

I attached an example output from the `/metrics` endpoint.
[metrics.json](https://github.com/apache/solr-sandbox/files/13451508/metrics.json)
