### PR TITLE
Encrypt handler calls EncryptionUpdateLog to reencrypt logs. Rewrite the test.

### DIFF
--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectoryFactory.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectoryFactory.java
@@ -78,7 +78,7 @@ public class EncryptionDirectoryFactory extends MMapDirectoryFactory {
     }
     KeySupplier.Factory keySupplierFactory = coreContainer.getResourceLoader().newInstance(keySupplierFactoryClass,
                                                                                           KeySupplier.Factory.class);
-    keySupplierFactory.init(args);
+    keySupplierFactory.init(args, coreContainer);
     try {
       keySupplier = keySupplierFactory.create();
     } catch (IOException e) {

--- a/encryption/src/main/java/org/apache/solr/encryption/KeySupplier.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/KeySupplier.java
@@ -18,7 +18,7 @@ package org.apache.solr.encryption;
 
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.solr.common.util.NamedList;
-import org.apache.solr.util.plugin.NamedListInitializedPlugin;
+import org.apache.solr.core.CoreContainer;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -70,10 +70,14 @@ public interface KeySupplier extends Closeable {
   /**
    * Creates {@link KeySupplier}.
    */
-  interface Factory extends NamedListInitializedPlugin {
+  interface Factory {
 
-    /** This factory may be configured with parameters defined in solrconfig.xml. */
-    void init(NamedList<?> args);
+    /**
+     * Initializes this factory.
+     *
+     * @param args non-null list of initialization parameters (may be empty).
+     */
+    void init(NamedList<?> args, CoreContainer coreContainer);
 
     /** Creates a {@link KeySupplier}. */
     KeySupplier create() throws IOException;

--- a/encryption/src/main/java/org/apache/solr/encryption/crypto/CharStreamEncrypter.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/crypto/CharStreamEncrypter.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -48,6 +49,23 @@ public class CharStreamEncrypter {
 
   public CharStreamEncrypter(AesCtrEncrypterFactory factory) {
     this.factory = factory;
+  }
+
+  /**
+   * Encrypts an input string to base 64 characters compatible with JSON.
+   *
+   * @param key AES key, can either 16, 24 or 32 bytes.
+   * @return the encrypted base 64 chars.
+   */
+  public String encrypt(String input, byte[] key) {
+    StringBuilder output = new StringBuilder(input.length() * 2);
+    try {
+      encrypt(input, key, output);
+    } catch (IOException e) {
+      // Never happens when appending to a StringBuilder.
+      throw new UncheckedIOException(e);
+    }
+    return output.toString();
   }
 
   /**
@@ -95,6 +113,23 @@ public class CharStreamEncrypter {
                bufferSize
       );
     }
+  }
+
+  /**
+   * Decrypts an input string previously encrypted with {@link #encrypt}.
+   *
+   * @param key AES key, can either 16, 24 or 32 bytes.
+   * @return the decrypted chars.
+   */
+  public String decrypt(String input, byte[] key) {
+    StringBuilder output = new StringBuilder((int) (input.length() * 0.6f));
+    try {
+      decrypt(input, key, output);
+    } catch (IOException e) {
+      // Never happens when appending to a StringBuilder.
+      throw new UncheckedIOException(e);
+    }
+    return output.toString();
   }
 
   /**

--- a/encryption/src/main/java/org/apache/solr/encryption/crypto/EncryptingIndexOutput.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/crypto/EncryptingIndexOutput.java
@@ -83,7 +83,6 @@ public class EncryptingIndexOutput extends IndexOutput {
     throws IOException {
     super("Encrypting " + indexOutput.toString(), indexOutput.getName());
     this.indexOutput = indexOutput;
-
     byte[] iv = generateRandomIv();
     encrypter = factory.create(key, iv);
     encrypter.init(0);

--- a/encryption/src/main/java/org/apache/solr/update/TransactionLog.java
+++ b/encryption/src/main/java/org/apache/solr/update/TransactionLog.java
@@ -74,7 +74,7 @@ public class TransactionLog implements Closeable {
   public static final String END_MESSAGE = "SOLR_TLOG_END";
 
   long id;
-  Path tlog;
+  protected Path tlog;
   protected FileChannel channel;
   protected OutputStream os;
   // all accesses to this stream should be synchronized on "this" (The TransactionLog)

--- a/encryption/src/test/java/org/apache/solr/encryption/TestingKeySupplier.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/TestingKeySupplier.java
@@ -18,6 +18,7 @@ package org.apache.solr.encryption;
 
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.CoreContainer;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -177,7 +178,7 @@ public class TestingKeySupplier implements KeySupplier {
     private static final KeySupplier SINGLETON = new TestingKeySupplier();
 
     @Override
-    public void init(NamedList<?> args) {
+    public void init(NamedList<?> args, CoreContainer coreContainer) {
       // Do nothing.
     }
 

--- a/encryption/src/test/java/org/apache/solr/encryption/crypto/AesCtrEncrypterTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/crypto/AesCtrEncrypterTest.java
@@ -20,6 +20,7 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.junit.Test;
 
 import static org.apache.solr.encryption.crypto.AesCtrUtil.*;
+import static org.apache.solr.encryption.crypto.CryptoTestUtil.encrypterFactory;
 import static org.junit.Assert.assertArrayEquals;
 
 /**
@@ -53,13 +54,6 @@ public class AesCtrEncrypterTest extends RandomizedTest {
         throw new RuntimeException("Exception at i=" + i, e);
       }
     }
-  }
-
-  private AesCtrEncrypterFactory encrypterFactory() {
-    if (LightAesCtrEncrypter.isSupported()) {
-      return randomBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
-    }
-    return CipherAesCtrEncrypter.FACTORY;
   }
 
   private static byte[] generateRandomBytes(int numBytes) {

--- a/encryption/src/test/java/org/apache/solr/encryption/crypto/CharStreamEncrypterTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/crypto/CharStreamEncrypterTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.apache.solr.encryption.crypto.CryptoTestUtil.encrypterFactory;
 import static org.junit.Assert.assertEquals;
 
 /** Tests {@link CharStreamEncrypter}. */
@@ -53,12 +54,5 @@ public class CharStreamEncrypterTest extends RandomizedTest {
     StringBuilder decryptedBuilder = new StringBuilder();
     encrypter.decrypt(encryptedBuilder.toString(), key, decryptedBuilder);
     assertEquals(inputString, decryptedBuilder.toString());
-  }
-
-  private AesCtrEncrypterFactory encrypterFactory() {
-    if (LightAesCtrEncrypter.isSupported()) {
-      return randomBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
-    }
-    return CipherAesCtrEncrypter.FACTORY;
   }
 }

--- a/encryption/src/test/java/org/apache/solr/encryption/crypto/CryptoTestUtil.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/crypto/CryptoTestUtil.java
@@ -14,24 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.solr.encryption;
+package org.apache.solr.encryption.crypto;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.channels.FileChannel;
-import java.util.concurrent.atomic.AtomicInteger;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
-public class TestingEncryptionUpdateLog extends EncryptionUpdateLog {
+/**
+ * Tools for encryption tests.
+ */
+public class CryptoTestUtil {
 
-  public static AtomicInteger reencryptionCallCount = new AtomicInteger();
-
-  protected void reencrypt(FileChannel inputChannel,
-                           String inputKeyRef,
-                           OutputStream outputStream,
-                           String activeKeyRef,
-                           EncryptionDirectory directory)
-    throws IOException {
-    super.reencrypt(inputChannel, inputKeyRef, outputStream, activeKeyRef, directory);
-    reencryptionCallCount.incrementAndGet();
+  /**
+   * Provides an {@link AesCtrEncrypterFactory} selected randomly.
+   */
+  public static AesCtrEncrypterFactory encrypterFactory() {
+    if (LightAesCtrEncrypter.isSupported()) {
+      return RandomizedTest.randomBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
+    }
+    return CipherAesCtrEncrypter.FACTORY;
   }
 }

--- a/encryption/src/test/java/org/apache/solr/encryption/crypto/DecryptingChannelInputStreamTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/crypto/DecryptingChannelInputStreamTest.java
@@ -30,6 +30,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import static org.apache.solr.encryption.crypto.AesCtrUtil.IV_LENGTH;
+import static org.apache.solr.encryption.crypto.CryptoTestUtil.encrypterFactory;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -78,10 +79,6 @@ public class DecryptingChannelInputStreamTest extends RandomizedTest {
     assertEquals(-1, dc.read(decryptedBytes, 0, 1));
     dc.close();
     assertArrayEquals(source, decryptedBytes);
-  }
-
-  private static AesCtrEncrypterFactory encrypterFactory() {
-    return randomBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
   }
 
   private static void write(byte[] source, int offset, int length, OutputStream os) throws IOException {

--- a/encryption/src/test/java/org/apache/solr/encryption/crypto/DecryptingIndexInputTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/crypto/DecryptingIndexInputTest.java
@@ -35,6 +35,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.apache.solr.encryption.crypto.CryptoTestUtil.encrypterFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -261,9 +262,5 @@ public class DecryptingIndexInputTest extends RandomizedTest {
     IndexInput indexInput = new ByteBuffersIndexInput(dataOutput.toDataInput(), "Test");
     indexInput.seek(offset);
     return new DecryptingIndexInput(indexInput, key, encrypterFactory());
-  }
-
-  private AesCtrEncrypterFactory encrypterFactory() {
-    return randomBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
   }
 }

--- a/encryption/src/test/java/org/apache/solr/encryption/crypto/EncryptingIndexOutputTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/crypto/EncryptingIndexOutputTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
 import static org.apache.solr.encryption.crypto.AesCtrUtil.*;
+import static org.apache.solr.encryption.crypto.CryptoTestUtil.encrypterFactory;
 
 /**
  * Tests {@link EncryptingIndexOutput}.
@@ -115,10 +116,6 @@ public class EncryptingIndexOutputTest extends BaseDataOutputTestCase<Encrypting
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-  }
-
-  private AesCtrEncrypterFactory encrypterFactory() {
-    return randomBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
   }
 
   /**

--- a/encryption/src/test/java/org/apache/solr/encryption/crypto/EncryptingOutputStreamTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/crypto/EncryptingOutputStreamTest.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import static org.apache.solr.encryption.crypto.AesCtrUtil.IV_LENGTH;
+import static org.apache.solr.encryption.crypto.CryptoTestUtil.encrypterFactory;
 import static org.junit.Assert.*;
 
 /**
@@ -115,10 +116,6 @@ public class EncryptingOutputStreamTest extends RandomizedTest {
     assertEquals(-1, dis.read(decryptedBytes, 0, 1));
     dis.close();
     assertArrayEquals(source, decryptedBytes);
-  }
-
-  private static AesCtrEncrypterFactory encrypterFactory() {
-    return randomBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
   }
 
   private static void write(byte[] source, int offset, int length, OutputStream os) throws IOException {

--- a/encryption/src/test/resources/configs/collection1/solrconfig.xml
+++ b/encryption/src/test/resources/configs/collection1/solrconfig.xml
@@ -47,7 +47,7 @@
   <!-- EncryptionUpdateHandler transfers the encryption key ids from a commit to the next. -->
   <updateHandler class="org.apache.solr.encryption.EncryptionUpdateHandler">
     <!-- EncryptionUpdateLog encrypts transaction logs if the index is encrypted. -->
-    <updateLog class="org.apache.solr.encryption.TestingEncryptionUpdateLog"/>
+    <updateLog class="${solr.updateLog:org.apache.solr.encryption.EncryptionUpdateLog}"/>
   </updateHandler>
 
   <!-- Encryption handler can be called to trigger the encryption of the index and update log. -->


### PR DESCRIPTION
A better test showed some interactions between EncryptionRequestHandler and EncryptionUpdateLog missed.
This PR adds some methods in EncryptionUpdateLog and makes EncryptionRequestHandler call them.

Also refactor some parts of tests classes to share common code.