### PR TITLE
Remove EncryptionDirectory.shouldCheckEncryptionWhenReading optimization.

### DIFF
--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionUpdateLog.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionUpdateLog.java
@@ -177,9 +177,11 @@ public class EncryptionUpdateLog extends UpdateLog {
                                          directory.getKeySecret(inputKeyRef),
                                          directory.getEncrypterFactory());
     if (activeKeyRef != null) {
+      // Get the key secret first. If it fails, we do not write anything.
+      byte[] keySecret = directory.getKeySecret(activeKeyRef);
       writeEncryptionHeader(activeKeyRef, outputStream);
       outputStream = new EncryptingOutputStream(outputStream,
-                                                directory.getKeySecret(activeKeyRef),
+                                                keySecret,
                                                 directory.getEncrypterFactory());
     }
     byte[] buffer = new byte[REENCRYPTION_BUFFER_SIZE];

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionUtil.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionUtil.java
@@ -130,18 +130,6 @@ public class EncryptionUtil {
   }
 
   /**
-   * @return Whether the provided commit user data contain some encryption key ids (active or not).
-   */
-  public static boolean hasKeyIdInCommit(Map<String, String> commitUserData) {
-    for (String entryKey : commitUserData.keySet()) {
-      if (entryKey.startsWith(COMMIT_KEY_ID)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Gets the cookies (key-value pairs) for all the key ids, from the provided commit user data.
    *
    * @return the cookies for all key ids.


### PR DESCRIPTION
Remove the optimization as it does not work in the case of an initially empty directory that is later filled with the index files. Also, it does not bring much performance or IO improvement.