### PR TITLE
Remove encryption log prefix.

### DIFF
--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectory.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectory.java
@@ -301,8 +301,7 @@ public class EncryptionDirectory extends FilterDirectory {
     throws IOException {
     List<SegmentCommitInfo> segmentsWithOldKeyId = null;
     if (log.isDebugEnabled()) {
-      log.debug("{} reading segments {} for key ids different from {}",
-                ENCRYPTION_LOG_PREFIX,
+      log.debug("Reading segments {} for key ids different from {}",
                 segmentInfos.asList().stream().map(i -> i.info.name).collect(Collectors.toList()),
                 activeKeyId);
     }
@@ -312,8 +311,8 @@ public class EncryptionDirectory extends FilterDirectory {
           try (IndexInput fileInput = in.openInput(fileName, IOContext.READ)) {
             String keyRef = getKeyRefForReading(fileInput);
             String keyId = keyRef == null ? null : getKeyIdFromCommit(keyRef, segmentInfos.getUserData());
-            log.debug("{} reading file {} of segment {} => keyId={}",
-                      ENCRYPTION_LOG_PREFIX, fileName, segmentCommitInfo.info.name, keyId);
+            log.debug("Reading file {} of segment {} => keyId={}",
+                      fileName, segmentCommitInfo.info.name, keyId);
             if (!Objects.equals(keyId, activeKeyId)) {
               if (segmentsWithOldKeyId == null) {
                 segmentsWithOldKeyId = new ArrayList<>();

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionMergePolicy.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionMergePolicy.java
@@ -64,8 +64,8 @@ public class EncryptionMergePolicy extends FilterMergePolicy {
     if (!(dir instanceof EncryptionDirectory)) {
       // This may happen if the DirectoryFactory configured is not the EncryptionDirectoryFactory,
       // but this is a misconfiguration. Let's log an error.
-      log.error("{} {} is configured whereas {} is not set; check the DirectoryFactory configuration",
-                ENCRYPTION_LOG_PREFIX, getClass().getName(), EncryptionDirectoryFactory.class.getName());
+      log.error("{} is configured whereas {} is not set; check the DirectoryFactory configuration",
+                getClass().getName(), EncryptionDirectoryFactory.class.getName());
       return super.findForcedMerges(segmentInfos, maxSegmentCount, segmentsToMerge, mergeContext);
     }
     String keyRef = getActiveKeyRefFromCommit(segmentInfos.getUserData());

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionUpdateLog.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionUpdateLog.java
@@ -45,7 +45,6 @@ import java.util.Objects;
 import static org.apache.solr.encryption.EncryptionTransactionLog.ENCRYPTION_KEY_HEADER_LENGTH;
 import static org.apache.solr.encryption.EncryptionTransactionLog.readEncryptionHeader;
 import static org.apache.solr.encryption.EncryptionTransactionLog.writeEncryptionHeader;
-import static org.apache.solr.encryption.EncryptionUtil.ENCRYPTION_LOG_PREFIX;
 import static org.apache.solr.encryption.EncryptionUtil.getActiveKeyRefFromCommit;
 import static org.apache.solr.encryption.EncryptionUtil.getKeyIdFromCommit;
 
@@ -76,7 +75,7 @@ public class EncryptionUpdateLog extends UpdateLog {
     try {
       encryptLogs();
     } catch (IOException e) {
-      log.error("{} exception while encrypting old transaction logs", ENCRYPTION_LOG_PREFIX, e);
+      log.error("Exception while encrypting old transaction logs", e);
     }
   }
 
@@ -114,7 +113,7 @@ public class EncryptionUpdateLog extends UpdateLog {
       try {
         encryptLogs();
       } catch (IOException e) {
-        log.error("{} exception while encrypting old transaction logs", ENCRYPTION_LOG_PREFIX, e);
+        log.error("Exception while encrypting old transaction logs", e);
       }
     }
   }

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionUtil.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionUtil.java
@@ -36,9 +36,6 @@ public class EncryptionUtil {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  /** Log prefix for encryption, to ease log search. */
-  public static final String ENCRYPTION_LOG_PREFIX = "Encryption:";
-
   /**
    * Crypto parameter prefix, in the commit user data.
    * It includes the {@link EncryptionUpdateHandler#TRANSFERABLE_COMMIT_DATA} prefix to be transferred from a
@@ -177,7 +174,7 @@ public class EncryptionUtil {
       for (Integer keyRef : inactiveKeyRefs.subList(0, inactiveKeyRefs.size() - INACTIVE_KEY_IDS_TO_KEEP)) {
         commitUserData.remove(COMMIT_KEY_ID + keyRef);
         commitUserData.remove(COMMIT_KEY_COOKIE + keyRef);
-        log.info("{} removing inactive key ref={}", ENCRYPTION_LOG_PREFIX, keyRef);
+        log.info("Removing inactive key ref={}", keyRef);
       }
     }
   }


### PR DESCRIPTION
The "encryption" is not useful to search logs as one can search with the package name "encrypt". Remove this prefix for simpler code.