### PR TITLE
EncryptionBackupRepository to back up encrypted files.

### DIFF
--- a/encryption/build.gradle
+++ b/encryption/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'org.apache.solr:solr-core:9.3.0'
-    implementation 'org.apache.lucene:lucene-core:9.7.0'
+    implementation 'org.apache.solr:solr-core:9.6.0'
+    implementation 'org.apache.lucene:lucene-core:9.10.0'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
     // commons-io and commons-codec are only required by the tool class
@@ -42,8 +42,8 @@ dependencies {
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'commons-codec:commons-codec:1.16.0'
 
-    testImplementation 'org.apache.solr:solr-test-framework:9.3.0'
-    testImplementation 'org.apache.lucene:lucene-test-framework:9.7.0'
+    testImplementation 'org.apache.solr:solr-test-framework:9.6.0'
+    testImplementation 'org.apache.lucene:lucene-test-framework:9.10.0'
 }
 
 test {

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionBackupRepository.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionBackupRepository.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.encryption;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.DirectoryFactory;
+import org.apache.solr.core.backup.repository.DelegatingBackupRepository;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.apache.solr.core.backup.repository.AbstractBackupRepository.PARAM_VERIFY_CHECKSUM;
+
+/**
+ * Encryption {@link org.apache.solr.core.backup.repository.BackupRepository} that delegates
+ * to another {@link org.apache.solr.core.backup.repository.BackupRepository} and intercepts
+ * index files copy to check their checksum in the decrypted from, but to copy them in their
+ * encrypted form.
+ */
+public class EncryptionBackupRepository extends DelegatingBackupRepository {
+
+  @Override
+  public void init(NamedList<?> args) {
+    if (delegate != null) {
+      delegate.init(args);
+    }
+  }
+
+  @Override
+  protected NamedList<?> getDelegateInitArgs(NamedList<?> initArgs) {
+    NamedList<Object> newInitArgs = new NamedList<>(initArgs.size() + 1);
+    // Ensure the delegate does not verify the checksum, otherwise it would fail since we back up encrypted files.
+    newInitArgs.add(PARAM_VERIFY_CHECKSUM, Boolean.FALSE.toString());
+    newInitArgs.addAll(initArgs);
+    return newInitArgs;
+  }
+
+  @Override
+  public void copyIndexFileFrom(
+          Directory sourceDir, String sourceFileName, Directory destDir, String destFileName)
+          throws IOException {
+    // Read and verify the checksum with the potentially decrypting directory.
+    verifyChecksum(sourceDir, sourceFileName);
+    // Copy the index file with the unwrapped (delegate) directory to keep encryption.
+    super.copyIndexFileFrom(FilterDirectory.unwrap(sourceDir), sourceFileName, destDir, destFileName);
+  }
+
+  @Override
+  public void copyIndexFileFrom(
+          Directory sourceDir, String sourceFileName, URI destUri, String destFileName)
+          throws IOException {
+    // Read and verify the checksum with the potentially decrypting directory.
+    verifyChecksum(sourceDir, sourceFileName);
+    // Copy the index file with the unwrapped (delegate) directory to keep encryption.
+    super.copyIndexFileFrom(FilterDirectory.unwrap(sourceDir), sourceFileName, destUri, destFileName);
+  }
+
+  private void verifyChecksum(Directory sourceDir, String sourceFileName) throws IOException {
+    try (ChecksumIndexInput is = sourceDir.openChecksumInput(sourceFileName, DirectoryFactory.IOCONTEXT_NO_CACHE)) {
+      long left = is.length() - CodecUtil.footerLength();
+      long bufferSize = 8192;
+      byte[] buffer = new byte[(int) bufferSize];
+      while (left > 0) {
+        int toCopy = (int) Math.min(left, bufferSize);
+        is.readBytes(buffer, 0, toCopy);
+        left -= toCopy;
+      }
+      // Verify the checksum.
+      CodecUtil.checkFooter(is);
+    }
+  }
+
+  @Override
+  public void copyIndexFileTo(
+          URI sourceRepo, String sourceFileName, Directory destDir, String destFileName)
+          throws IOException {
+    // Copy the index file with the unwrapped (delegate) directory to avoid encrypting twice.
+    super.copyIndexFileTo(sourceRepo, sourceFileName, FilterDirectory.unwrap(destDir), destFileName);
+  }
+}

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionBackupRepositoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionBackupRepositoryTest.java
@@ -1,0 +1,258 @@
+package org.apache.solr.encryption;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.store.*;
+import org.apache.solr.cloud.api.collections.AbstractBackupRepositoryTest;
+import org.apache.solr.common.params.CoreAdminParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.DirectoryFactory;
+import org.apache.solr.core.PluginInfo;
+import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.core.backup.repository.BackupRepository;
+import org.apache.solr.core.backup.repository.BackupRepositoryFactory;
+import org.apache.solr.core.backup.repository.LocalFileSystemRepository;
+import org.apache.solr.encryption.crypto.AesCtrEncrypterFactory;
+import org.apache.solr.encryption.crypto.CipherAesCtrEncrypter;
+import org.apache.solr.encryption.crypto.LightAesCtrEncrypter;
+import org.apache.solr.schema.FieldType;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.solr.core.backup.repository.DelegatingBackupRepository.PARAM_DELEGATE_REPOSITORY_NAME;
+import static org.apache.solr.encryption.EncryptionDirectory.ENCRYPTION_MAGIC;
+import static org.apache.solr.encryption.EncryptionUtil.COMMIT_ACTIVE_KEY;
+
+/**
+ * Tests {@link EncryptionBackupRepository}.
+ */
+public class EncryptionBackupRepositoryTest extends AbstractBackupRepositoryTest {
+
+    private static URI baseUri;
+
+    @BeforeClass
+    public static void setupBaseDir() {
+        baseUri = createTempDir().toUri();
+    }
+
+    @Override
+    protected Class<? extends BackupRepository> getRepositoryClass() {
+        return EncryptionBackupRepository.class;
+    }
+
+    @Override
+    protected BackupRepository getRepository() {
+        TestEncryptionBackupRepository repo = new TestEncryptionBackupRepository();
+        repo.init(getBaseBackupRepositoryConfiguration());
+        BackupRepository delegate = new LocalFileSystemRepository();
+        delegate.init(getBaseBackupRepositoryConfiguration());
+        repo.setDelegate(delegate);
+        return repo;
+    }
+
+    @Override
+    protected URI getBaseUri() throws URISyntaxException {
+        return baseUri;
+    }
+
+    /**
+     * Ignore this inherited test. Instead, test how encrypted files are checked and copied,
+     * as this relies on the same mechanism.
+     */
+    @Ignore
+    @Override
+    public void testCanDisableChecksumVerification() {
+    }
+
+    /**
+     * Tests a backup of an encrypted file.
+     * The checksum is verified in the decrypted form of the file, otherwise it fails.
+     * The backup copy is kept in its encrypted form, and not decrypted by the {@link EncryptionDirectory}.
+     */
+    @Test
+    public void testEncryptedBackup() throws Exception {
+        // Given two BackupRepository plugins:
+        // - A LocalFileSystemRepository plugin.
+        // - An EncryptionBackupRepository that delegates to the previous one.
+        String localRepoName = "localRepo";
+        String encryptionRepoName = "encryptionRepo";
+        NamedList<Object> encryptionRepoArgs = new NamedList<>();
+        encryptionRepoArgs.add(PARAM_DELEGATE_REPOSITORY_NAME, localRepoName);
+        PluginInfo[] plugins =
+                new PluginInfo[]{
+                        getPluginInfo(localRepoName, LocalFileSystemRepository.class, false, new NamedList<>()),
+                        getPluginInfo(encryptionRepoName, EncryptionBackupRepository.class, true, encryptionRepoArgs),
+                };
+        Collections.shuffle(Arrays.asList(plugins), random());
+
+        // Given an encrypted file on the local disk.
+        Path sourcePath = createTempDir().toAbsolutePath();
+        AesCtrEncrypterFactory encrypterFactory = random().nextBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
+        KeySupplier keySupplier = new TestingKeySupplier.Factory().create();
+        try (Directory fsSourceDir = FSDirectory.open(sourcePath);
+             Directory encSourceDir = new TestEncryptionDirectory(fsSourceDir, encrypterFactory, keySupplier);
+             Directory destinationDir = FSDirectory.open(createTempDir().toAbsolutePath())) {
+            String fileName = "source-file";
+            String content = "content";
+            try (IndexOutput out = encSourceDir.createOutput(fileName, IOContext.DEFAULT)) {
+                byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+                out.writeBytes(bytes, bytes.length);
+                CodecUtil.writeFooter(out);
+            }
+
+            BackupRepositoryFactory repoFactory = new BackupRepositoryFactory(plugins);
+            try (SolrResourceLoader resourceLoader = new SolrResourceLoader(sourcePath)) {
+
+                // When we copy the encrypted file with the LocalFileSystemRepository,
+                // then it fails because the encrypted checksum is invalid.
+                String destinationFolder = "destination-folder";
+                expectThrows(
+                        CorruptIndexException.class,
+                        () -> copyFileToRepo(fsSourceDir, fileName, localRepoName, destinationFolder, repoFactory, resourceLoader));
+                expectThrows(
+                        CorruptIndexException.class,
+                        () ->
+                                copyFileToDir(
+                                        fsSourceDir, fileName, destinationDir, localRepoName, repoFactory, resourceLoader));
+
+                // When we copy the encrypted file with the EncryptionBackupRepository,
+                // then it succeeds because the checksum is verified in decrypted form,
+                // and the file is copied in encrypted form.
+                copyFileToRepo(encSourceDir, fileName, encryptionRepoName, destinationFolder, repoFactory, resourceLoader);
+                // Check the copy starts with the encryption magic, not the regular codec magic, this means it is encrypted.
+                assertEquals(ENCRYPTION_MAGIC, readCodecMagic(fileName, encryptionRepoName, destinationFolder, repoFactory, resourceLoader));
+                copyFileToDir(
+                        encSourceDir, fileName, destinationDir, encryptionRepoName, repoFactory, resourceLoader);
+                // Check the copy starts with the encryption magic, not the regular codec magic, this means it is encrypted.
+                assertEquals(ENCRYPTION_MAGIC, readCodecMagic(fileName, destinationDir));
+
+                // When we restore the encrypted copy with the EncryptionBackupRepository,
+                // then the file is restored in its encrypted form.
+                try (BackupRepository repo = repoFactory.newInstance(resourceLoader, encryptionRepoName)) {
+                    URI repoDir = repo.resolve(getBaseUri(), destinationFolder);
+                    String restoreFileName = "restore-file";
+                    repo.copyIndexFileTo(repoDir, fileName, encSourceDir, restoreFileName);
+                    // Check the restored file starts with the encryption magic, not the regular codec magic, this means it is encrypted.
+                    assertEquals(ENCRYPTION_MAGIC, readCodecMagic(restoreFileName, fsSourceDir));
+                    // Check the restored file checksum to ensure it can be decrypted properly.
+                    verifyChecksum(encSourceDir, restoreFileName);
+                }
+            }
+        }
+    }
+
+    private PluginInfo getPluginInfo(
+            String pluginName, Class<? extends BackupRepository> repoClass, boolean isDefault, NamedList<Object> initArgs) {
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(CoreAdminParams.NAME, pluginName);
+        attrs.put(FieldType.CLASS_NAME, repoClass.getName());
+        attrs.put("default", Boolean.toString(isDefault));
+        return new PluginInfo("repository", attrs, initArgs, null);
+    }
+
+    private void copyFileToRepo(
+            Directory dir,
+            String fileName,
+            String repoName,
+            String destinationFolder,
+            BackupRepositoryFactory repoFactory,
+            SolrResourceLoader resourceLoader)
+            throws IOException, URISyntaxException {
+        try (BackupRepository repo = repoFactory.newInstance(resourceLoader, repoName)) {
+            URI destinationDir = repo.resolve(getBaseUri(), destinationFolder);
+            repo.copyIndexFileFrom(dir, fileName, destinationDir, fileName);
+        }
+    }
+
+    private void copyFileToDir(
+            Directory sourceDir,
+            String fileName,
+            Directory destinationDir,
+            String repoName,
+            BackupRepositoryFactory repoFactory,
+            SolrResourceLoader resourceLoader)
+            throws IOException {
+        try (BackupRepository repo = repoFactory.newInstance(resourceLoader, repoName)) {
+            repo.copyIndexFileFrom(sourceDir, fileName, destinationDir, fileName);
+        }
+    }
+
+    private int readCodecMagic(
+            String fileName,
+            String repoName,
+            String destinationFolder,
+            BackupRepositoryFactory repoFactory,
+            SolrResourceLoader resourceLoader)
+            throws IOException, URISyntaxException {
+        try (BackupRepository repo = repoFactory.newInstance(resourceLoader, repoName)) {
+            URI destinationUri = repo.resolve(getBaseUri(), destinationFolder);
+            try (Directory destinationDir = FSDirectory.open(Path.of(destinationUri))) {
+                return readCodecMagic(fileName, destinationDir);
+            }
+        }
+    }
+
+    private int readCodecMagic(String fileName, Directory destinationDir) throws IOException {
+        try (IndexInput in = destinationDir.openInput(fileName, IOContext.READ)) {
+            return CodecUtil.readBEInt(in);
+        }
+    }
+
+    private void verifyChecksum(Directory sourceDir, String sourceFileName) throws IOException {
+        try (ChecksumIndexInput is = sourceDir.openChecksumInput(sourceFileName, DirectoryFactory.IOCONTEXT_NO_CACHE)) {
+            long left = is.length() - CodecUtil.footerLength();
+            long bufferSize = 8192;
+            byte[] buffer = new byte[(int) bufferSize];
+            while (left > 0) {
+                int toCopy = (int) Math.min(left, bufferSize);
+                is.readBytes(buffer, 0, toCopy);
+                left -= toCopy;
+            }
+            // Verify the checksum.
+            CodecUtil.checkFooter(is);
+        }
+    }
+
+    /**
+     * Makes {@link #setDelegate} accessible.
+     */
+    private static class TestEncryptionBackupRepository extends EncryptionBackupRepository {
+
+        @Override
+        public void setDelegate(BackupRepository delegate) {
+            super.setDelegate(delegate);
+        }
+    }
+
+    /**
+     * Mocks a key secret in the commit metadata.
+     */
+    private static class TestEncryptionDirectory extends EncryptionDirectory {
+
+        TestEncryptionDirectory(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeySupplier keySupplier)
+                throws IOException {
+            super(delegate, encrypterFactory, keySupplier);
+        }
+
+        @Override
+        protected CommitUserData readLatestCommitUserData() {
+            return new CommitUserData("test", Map.of(COMMIT_ACTIVE_KEY, "0"));
+        }
+
+        @Override
+        protected byte[] getKeySecret(String keyRef) {
+            return TestingKeySupplier.KEY_SECRET_1;
+        }
+    }
+}

--- a/encryption/src/test/resources/configs/collection1/solrconfig.xml
+++ b/encryption/src/test/resources/configs/collection1/solrconfig.xml
@@ -68,4 +68,14 @@
     </mergePolicyFactory>
   </indexConfig>
 
+  <backup>
+    <!-- Encryption backup repository delegates to another backup repository. -->
+    <repository name="encryptionBackupRepository" class="org.apache.solr.encryption.EncryptionBackupRepository" default="true">
+      <str name="delegateRepoName">localBackupRepository</str>
+    </repository>
+    <repository name="localBackupRepository" class="org.apache.solr.core.backup.repository.LocalFileSystemRepository">
+      <str name="location">/solr/backup_data</str>
+    </repository>
+  </backup>
+
 </config>


### PR DESCRIPTION
A new EncryptionBackupRepository is required to backup correctly files encrypted with the EncryptionDirectory, otherwise index files are decrypted before the backup copy. EncryptionBackupRepository ensures the encrypted files are copied encrypted, but still verifies their checksum before the copy. It also ensures the files are copied encrypted when restored (not double encrypted).

EncryptionBackupRepository extends DelegatingBackupRepository, so it requires solr 9.6.0.