### PR TITLE
Transfer encryption metadata in the commit when DirectUpdateHandler2.closeWriter is called.

### DIFF
--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectory.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectory.java
@@ -127,7 +127,6 @@ public class EncryptionDirectory extends FilterDirectory {
    */
   protected IndexOutput maybeWrapOutput(IndexOutput indexOutput) throws IOException {
     String fileName = indexOutput.getName();
-    assert !fileName.startsWith(IndexFileNames.SEGMENTS);
     if (fileName.startsWith(IndexFileNames.PENDING_SEGMENTS)) {
       // The pending_segments file should not be encrypted. Do not wrap the IndexOutput.
       // It also means a commit has started, so set the flag to read the commit user data
@@ -135,8 +134,9 @@ public class EncryptionDirectory extends FilterDirectory {
       shouldReadCommitUserData = true;
       return indexOutput;
     }
-    if (!keySupplier.shouldEncrypt(fileName)) {
+    if (fileName.startsWith(IndexFileNames.SEGMENTS) || !keySupplier.shouldEncrypt(fileName)) {
       // The file should not be encrypted, based on its name. Do not wrap the IndexOutput.
+      // (the segments file can be opened by the IndexFetcher)
       return indexOutput;
     }
     boolean success = false;

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
@@ -282,9 +282,14 @@ public class EncryptionRequestHandlerTest extends SolrCloudTestCase {
     }
 
     testUtil.commit();
+    testUtil.waitUntilEncryptionIsComplete(KEY_ID_1);
 
     // Verify that the segment is encrypted.
+    forceClearText = true;
+    testUtil.assertCannotReloadCores();
+    forceClearText = false;
     soleKeyIdAllowed = KEY_ID_1;
+    testUtil.reloadCores();
     testUtil.assertQueryReturns("weather", 1);
   }
 

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionTestUtil.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionTestUtil.java
@@ -129,12 +129,26 @@ public class EncryptionTestUtil {
    * Adds one doc per provided text, and commits.
    */
   public void indexDocsAndCommit(String... texts) throws Exception {
+    indexDocsNoCommit(texts);
+    commit();
+  }
+
+  /**
+   * Adds one doc per provided text, but does not commit.
+   */
+  public void indexDocsNoCommit(String... texts) throws Exception {
     for (String text : texts) {
       SolrInputDocument doc = new SolrInputDocument();
       doc.addField("id", Integer.toString(docId++));
       doc.addField("text", text);
       cloudSolrClient.add(collectionName, doc);
     }
+  }
+
+  /**
+   * Commits.
+   */
+  public void commit() throws Exception {
     cloudSolrClient.commit(collectionName);
   }
 


### PR DESCRIPTION
The problem is described in the corresponding [issue](https://github.com/apache/solr-sandbox/issues/109).
It happens when documents are inserted but without commit, and the IndexWriter is closed, which triggers an auto-commit from DirectUpdateHandler2.closeWriter. Unfortunately this auto-commit does not really call the DirectUpdateHandler2.commit code but rather copies it, and we miss a call to DirectUpdateHandler2.shouldCommit to manage the encryption commit metadata.

Actually this requires to change DirectUpdateHandler2.closeWriter in the Solr project.
This PR shows the small required change (see comment in the DirectUpdateHandler2 copy), and verifies the fix with a test.
But I don't think I'll merge this PR. I'll rather change upstream and wait for the next release to upgrade here.