### PR TITLE
EncryptionRequestHandler supports encryption requests distribution.

### DIFF
--- a/encryption/build.gradle
+++ b/encryption/build.gradle
@@ -33,22 +33,22 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'org.apache.solr:solr-core:9.6.0'
-    implementation 'org.apache.lucene:lucene-core:9.10.0'
+    implementation 'org.apache.solr:solr-core:9.8.0'
+    implementation 'org.apache.lucene:lucene-core:9.11.1'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
-    // Optional, used by the KmsKeySupplier.
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    // Optional, used by the KmsKeySupplier example.
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.2.0'
     implementation 'io.opentracing:opentracing-util:0.33.0'
 
     // Optional, commons-io and commons-codec are only required by the
     // tool class CharStreamEncrypter, which is not used for the index
     // encryption.
-    implementation 'commons-io:commons-io:2.11.0'
-    implementation 'commons-codec:commons-codec:1.16.0'
+    implementation 'commons-io:commons-io:2.18.0'
+    implementation 'commons-codec:commons-codec:1.18.0'
 
-    testImplementation 'org.apache.solr:solr-test-framework:9.6.0'
-    testImplementation 'org.apache.lucene:lucene-test-framework:9.10.0'
+    testImplementation 'org.apache.solr:solr-test-framework:9.8.0'
+    testImplementation 'org.apache.lucene:lucene-test-framework:9.11.1'
 }
 
 test {

--- a/encryption/src/main/java/org/apache/solr/encryption/crypto/CharStreamEncrypter.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/crypto/CharStreamEncrypter.java
@@ -39,6 +39,9 @@ import java.nio.charset.StandardCharsets;
  * buffers allocated. The encryption transformation is AES/CTR/NoPadding.
  * A secure random IV is generated for each encryption and appended as the first
  * appended chars.
+ * <p>
+ * This encryption tool is intended to encrypt write-once and then read-only strings,
+ * it should not be used to encrypt updatable content as CTR is not designed for that.
  */
 public class CharStreamEncrypter {
 

--- a/encryption/src/main/java/org/apache/solr/encryption/kms/KmsEncryptionRequestHandler.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/kms/KmsEncryptionRequestHandler.java
@@ -52,9 +52,8 @@ public class KmsEncryptionRequestHandler extends EncryptionRequestHandler {
 
   @Override
   protected ModifiableSolrParams createDistributedRequestParams(SolrQueryRequest req, SolrQueryResponse rsp, String keyId) {
-    ModifiableSolrParams params = super.createDistributedRequestParams(req, rsp, keyId);
-    params.add(PARAM_TENANT_ID, getRequiredRequestParam(req, PARAM_TENANT_ID, rsp));
-    params.add(PARAM_ENCRYPTION_KEY_BLOB, getRequiredRequestParam(req, PARAM_ENCRYPTION_KEY_BLOB, rsp));
-    return params;
+    return super.createDistributedRequestParams(req, rsp, keyId)
+        .set(PARAM_TENANT_ID, getRequiredRequestParam(req, PARAM_TENANT_ID, rsp))
+        .set(PARAM_ENCRYPTION_KEY_BLOB, getRequiredRequestParam(req, PARAM_ENCRYPTION_KEY_BLOB, rsp));
   }
 }

--- a/encryption/src/main/java/org/apache/solr/encryption/kms/KmsEncryptionRequestHandler.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/kms/KmsEncryptionRequestHandler.java
@@ -1,6 +1,7 @@
 package org.apache.solr.encryption.kms;
 
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.encryption.EncryptionRequestHandler;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
@@ -14,38 +15,46 @@ import java.util.Map;
  */
 public class KmsEncryptionRequestHandler extends EncryptionRequestHandler {
 
-    /**
-     * Tenant Id request parameter - required.
-     */
-    public static final String PARAM_TENANT_ID = "tenantId";
-    /**
-     * Data Key Blob request parameter - required.
-     */
-    public static final String PARAM_ENCRYPTION_KEY_BLOB = "encryptionKeyBlob";
+  /**
+   * Tenant Id request parameter - required.
+   */
+  public static final String PARAM_TENANT_ID = "tenantId";
+  /**
+   * Data Key Blob request parameter - required.
+   */
+  public static final String PARAM_ENCRYPTION_KEY_BLOB = "encryptionKeyBlob";
 
-    /**
-     *  Builds the KMS key cookie based on key id and key blob parameters of the request.
-     *  If a required parameter is missing, this method throws a {@link SolrException} with
-     *  {@link SolrException.ErrorCode#BAD_REQUEST} and sets the response status to failure.
-     */
-    @Override
-    protected Map<String, String> buildKeyCookie(String keyId,
-                                                 SolrQueryRequest req,
-                                                 SolrQueryResponse rsp) {
-        String tenantId = getRequiredRequestParam(req, PARAM_TENANT_ID, rsp);
-        String encryptionKeyBlob = getRequiredRequestParam(req, PARAM_ENCRYPTION_KEY_BLOB, rsp);
-        return Map.of(
-                PARAM_TENANT_ID, tenantId,
-                PARAM_ENCRYPTION_KEY_BLOB, encryptionKeyBlob
-        );
-    }
+  /**
+   * Builds the KMS key cookie based on key id and key blob parameters of the request.
+   * If a required parameter is missing, this method throws a {@link SolrException} with
+   * {@link SolrException.ErrorCode#BAD_REQUEST} and sets the response status to failure.
+   */
+  @Override
+  protected Map<String, String> buildKeyCookie(String keyId,
+                                               SolrQueryRequest req,
+                                               SolrQueryResponse rsp) {
+    String tenantId = getRequiredRequestParam(req, PARAM_TENANT_ID, rsp);
+    String encryptionKeyBlob = getRequiredRequestParam(req, PARAM_ENCRYPTION_KEY_BLOB, rsp);
+    return Map.of(
+        PARAM_TENANT_ID, tenantId,
+        PARAM_ENCRYPTION_KEY_BLOB, encryptionKeyBlob
+    );
+  }
 
-    private String getRequiredRequestParam(SolrQueryRequest req, String param, SolrQueryResponse rsp) {
-        String arg = req.getParams().get(param);
-        if (arg == null || arg.isEmpty()) {
-            rsp.add(STATUS, STATUS_FAILURE);
-            throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Required parameter " + param + " must be present and not empty.");
-        }
-        return arg;
+  private String getRequiredRequestParam(SolrQueryRequest req, String param, SolrQueryResponse rsp) {
+    String arg = req.getParams().get(param);
+    if (arg == null || arg.isEmpty()) {
+      rsp.add(STATUS, STATUS_FAILURE);
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Required parameter " + param + " must be present and not empty.");
     }
+    return arg;
+  }
+
+  @Override
+  protected ModifiableSolrParams createDistributedRequestParams(SolrQueryRequest req, SolrQueryResponse rsp, String keyId) {
+    ModifiableSolrParams params = super.createDistributedRequestParams(req, rsp, keyId);
+    params.add(PARAM_TENANT_ID, getRequiredRequestParam(req, PARAM_TENANT_ID, rsp));
+    params.add(PARAM_ENCRYPTION_KEY_BLOB, getRequiredRequestParam(req, PARAM_ENCRYPTION_KEY_BLOB, rsp));
+    return params;
+  }
 }

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
@@ -233,11 +233,11 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
    * {@link EncryptionRequestHandler}, but this test is designed to work independently.
    */
   private void optimizeCommit() {
-    testUtil.forAllReplicas(replica -> {
+    testUtil.forAllReplicas(false, replica -> {
       UpdateRequest request = new UpdateRequest();
       request.setAction(UpdateRequest.ACTION.OPTIMIZE, true, true, 1);
       testUtil.requestCore(request, replica);
-    }, false);
+    });
   }
 
   public static class MockFactory implements EncryptionDirectoryFactory.InnerFactory {

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
@@ -80,7 +80,8 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
     solrClient = cluster.getSolrClient();
     CollectionAdminRequest.createCollection(collectionName, 2, 2).process(solrClient);
     cluster.waitForActiveCollection(collectionName, 2, 4);
-    testUtil = new EncryptionTestUtil(solrClient, collectionName);
+    testUtil = new EncryptionTestUtil(solrClient, collectionName)
+        .setShouldDistributeRequests(false);
   }
 
   @Override
@@ -236,7 +237,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
       UpdateRequest request = new UpdateRequest();
       request.setAction(UpdateRequest.ACTION.OPTIMIZE, true, true, 1);
       testUtil.requestCore(request, replica);
-    });
+    }, false);
   }
 
   public static class MockFactory implements EncryptionDirectoryFactory.InnerFactory {

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
@@ -30,7 +30,10 @@ import org.junit.Test;
 import org.apache.solr.encryption.crypto.AesCtrEncrypterFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -44,15 +47,10 @@ import static org.apache.solr.encryption.TestingKeySupplier.KEY_SECRET_2;
 
 /**
  * Tests {@link EncryptionDirectory}.
- * <p>
- * This test class ignores the DirectoryFactory defined in solrconfig.xml to use
- * {@link EncryptionDirectoryFactory}.
  */
 public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
   private static final String COLLECTION_PREFIX = EncryptionDirectoryTest.class.getSimpleName() + "-collection-";
-
-  private static MockEncryptionDirectory mockDir;
 
   private String collectionName;
   private CloudSolrClient solrClient;
@@ -86,9 +84,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
   @Override
   public void tearDown() throws Exception {
-    if (mockDir != null) {
-      mockDir.clearMockValues();
-    }
+    MockFactory.clearMockValues();
     CollectionAdminRequest.deleteCollection(collectionName).process(solrClient);
     super.tearDown();
   }
@@ -107,7 +103,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
    */
   private void indexAndEncryptOneSegment() throws Exception {
     // Start with no key ids defined in the latest commit metadata.
-    mockDir.clearMockValues();
+    MockFactory.clearMockValues();
     // Create 2 index segments without encryption.
     testUtil.indexDocsAndCommit("weather broadcast");
     testUtil.indexDocsAndCommit("sunny weather");
@@ -121,23 +117,23 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     // Set the encryption key id in the commit user data,
     // and run an optimized commit to rewrite the index, now encrypted.
-    mockDir.setKeysInCommitUserData(KEY_ID_1);
+    MockFactory.setKeysInCommitUserData(KEY_ID_1);
     optimizeCommit();
 
     // Verify that without key id, we cannot decrypt the index anymore.
-    mockDir.forceClearText = true;
+    MockFactory.forceClearText = true;
     testUtil.assertCannotReloadCores();
     // Verify that with a wrong key id, we cannot decrypt the index.
-    mockDir.forceClearText = false;
-    mockDir.forceKeySecret = KEY_SECRET_2;
+    MockFactory.forceClearText = false;
+    MockFactory.forceKeySecret = KEY_SECRET_2;
     testUtil.assertCannotReloadCores();
     // Verify that with the right key id, we can decrypt the index and search it.
-    mockDir.forceKeySecret = null;
-    mockDir.expectedKeySecret = KEY_SECRET_1;
+    MockFactory.forceKeySecret = null;
+    MockFactory.expectedKeySecrets = List.of(KEY_SECRET_1);
     testUtil.reloadCores();
     testUtil.assertQueryReturns("weather", 2);
     testUtil.assertQueryReturns("sunny", 1);
-    mockDir.clearMockValues();
+    MockFactory.clearMockValues();
   }
 
   /**
@@ -157,24 +153,24 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
     indexAndEncryptOneSegment();
 
     // Create 1 new segment with the same encryption key id.
-    mockDir.setKeysInCommitUserData(KEY_ID_1);
+    MockFactory.setKeysInCommitUserData(KEY_ID_1);
     testUtil.indexDocsAndCommit("foggy weather");
     testUtil.indexDocsAndCommit("boo");
 
     // Verify that without key id, we cannot decrypt the index.
-    mockDir.forceClearText = true;
+    MockFactory.forceClearText = true;
     testUtil.assertCannotReloadCores();
     // Verify that with a wrong key id, we cannot decrypt the index.
-    mockDir.forceClearText = false;
-    mockDir.forceKeySecret = KEY_SECRET_2;
+    MockFactory.forceClearText = false;
+    MockFactory.forceKeySecret = KEY_SECRET_2;
     testUtil.assertCannotReloadCores();
     // Verify that with the right key id, we can decrypt the index and search it.
-    mockDir.forceKeySecret = null;
-    mockDir.expectedKeySecret = KEY_SECRET_1;
+    MockFactory.forceKeySecret = null;
+    MockFactory.expectedKeySecrets = List.of(KEY_SECRET_1);
     testUtil.reloadCores();
     testUtil.assertQueryReturns("weather", 3);
     testUtil.assertQueryReturns("sunny", 1);
-    mockDir.clearMockValues();
+    MockFactory.clearMockValues();
   }
 
   /**
@@ -187,19 +183,19 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     // Set the new encryption key id in the commit user data,
     // and run an optimized commit to rewrite the index, now encrypted with the new key.
-    mockDir.setKeysInCommitUserData(KEY_ID_1, KEY_ID_2);
+    MockFactory.setKeysInCommitUserData(KEY_ID_1, KEY_ID_2);
     optimizeCommit();
 
     // Verify that without key id, we cannot decrypt the index.
-    mockDir.forceClearText = true;
+    MockFactory.forceClearText = true;
     testUtil.assertCannotReloadCores();
     // Verify that with a wrong key id, we cannot decrypt the index.
-    mockDir.forceClearText = false;
-    mockDir.forceKeySecret = KEY_SECRET_1;
+    MockFactory.forceClearText = false;
+    MockFactory.forceKeySecret = KEY_SECRET_1;
     testUtil.assertCannotReloadCores();
     // Verify that with the right key id, we can decrypt the index and search it.
-    mockDir.forceKeySecret = null;
-    mockDir.expectedKeySecret = KEY_SECRET_2;
+    MockFactory.forceKeySecret = null;
+    MockFactory.expectedKeySecrets = List.of(KEY_SECRET_1, KEY_SECRET_2);
     testUtil.reloadCores();
     testUtil.assertQueryReturns("weather", 3);
     testUtil.assertQueryReturns("sunny", 1);
@@ -215,11 +211,11 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     // Remove the active key parameter from the commit user data,
     // and run an optimized commit to rewrite the index, now cleartext with no keys.
-    mockDir.setKeysInCommitUserData(KEY_ID_1, null);
+    MockFactory.setKeysInCommitUserData(KEY_ID_1, null);
     optimizeCommit();
 
     // Verify that without key id, we can reload the index because it is not encrypted.
-    mockDir.forceClearText = true;
+    MockFactory.forceClearText = true;
     testUtil.reloadCores();
     testUtil.assertQueryReturns("weather", 3);
     testUtil.assertQueryReturns("sunny", 1);
@@ -241,20 +237,41 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
   }
 
   public static class MockFactory implements EncryptionDirectoryFactory.InnerFactory {
+
+    static final List<MockEncryptionDirectory> mockDirs = new ArrayList<>();
+
+    static boolean forceClearText;
+    static byte[] forceKeySecret;
+    static List<byte[]> expectedKeySecrets;
+
+    static void clearMockValues() {
+      forceClearText = false;
+      forceKeySecret = null;
+      expectedKeySecrets = null;
+      for (MockEncryptionDirectory mockDir : mockDirs) {
+        mockDir.clearMockValues();
+      }
+    }
+
+    static void setKeysInCommitUserData(String... keyIds) throws IOException {
+      for (MockEncryptionDirectory mockDir : mockDirs) {
+        mockDir.setKeysInCommitUserData(keyIds);
+      }
+    }
+
     @Override
     public EncryptionDirectory create(Directory delegate,
                                       AesCtrEncrypterFactory encrypterFactory,
                                       KeySupplier keySupplier) throws IOException {
-      return mockDir = new MockEncryptionDirectory(delegate, encrypterFactory, keySupplier);
+      MockEncryptionDirectory mockDir = new MockEncryptionDirectory(delegate, encrypterFactory, keySupplier);
+      mockDirs.add(mockDir);
+      return mockDir;
     }
   }
 
   private static class MockEncryptionDirectory extends EncryptionDirectory {
 
     final KeySupplier keySupplier;
-    boolean forceClearText;
-    byte[] forceKeySecret;
-    byte[] expectedKeySecret;
 
     MockEncryptionDirectory(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeySupplier keySupplier)
       throws IOException {
@@ -264,9 +281,6 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     void clearMockValues() {
       commitUserData = new CommitUserData(commitUserData.segmentFileName, Map.of());
-      forceClearText = false;
-      forceKeySecret = null;
-      expectedKeySecret = null;
     }
 
     /**
@@ -286,7 +300,7 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     @Override
     public IndexInput openInput(String fileName, IOContext context) throws IOException {
-      return forceClearText ? in.openInput(fileName, context) : super.openInput(fileName, context);
+      return MockFactory.forceClearText ? in.openInput(fileName, context) : super.openInput(fileName, context);
     }
 
     @Override
@@ -299,12 +313,19 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     @Override
     protected byte[] getKeySecret(String keyRef) throws IOException {
-      if (forceKeySecret != null) {
-        return forceKeySecret;
+      if (MockFactory.forceKeySecret != null) {
+        return MockFactory.forceKeySecret;
       }
       byte[] keySecret = super.getKeySecret(keyRef);
-      if (expectedKeySecret != null) {
-        assertArrayEquals(expectedKeySecret, keySecret);
+      if (MockFactory.expectedKeySecrets != null) {
+        boolean keySecretMatches = false;
+        for (byte[] expectedKeySecret : MockFactory.expectedKeySecrets) {
+          if (Arrays.equals(expectedKeySecret, keySecret)) {
+            keySecretMatches = true;
+            break;
+          }
+        }
+        assertTrue(keySecretMatches);
       }
       return keySecret;
     }

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 
 import static org.apache.solr.encryption.EncryptionDirectoryFactory.PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY;
 import static org.apache.solr.encryption.EncryptionRequestHandler.NO_KEY_ID;
+import static org.apache.solr.encryption.EncryptionRequestHandler.STATUS_SUCCESS;
 import static org.apache.solr.encryption.EncryptionUtil.getKeyIdFromCommit;
 import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_1;
 import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_2;
@@ -45,6 +46,8 @@ import static org.apache.solr.encryption.TestingKeySupplier.KEY_ID_2;
 public class EncryptionRequestHandlerTest extends SolrCloudTestCase {
 
   private static final String COLLECTION_PREFIX = EncryptionRequestHandlerTest.class.getSimpleName() + "-collection-";
+
+  protected static String configDir = "collection1";
 
   private static volatile boolean forceClearText;
   private static volatile String soleKeyIdAllowed;
@@ -58,7 +61,7 @@ public class EncryptionRequestHandlerTest extends SolrCloudTestCase {
     System.setProperty(PROPERTY_INNER_ENCRYPTION_DIRECTORY_FACTORY, MockFactory.class.getName());
     EncryptionTestUtil.setInstallDirProperty();
     cluster = new MiniSolrCloudCluster.Builder(2, createTempDir())
-      .addConfig("config", EncryptionTestUtil.getRandomConfigPath())
+      .addConfig("config", EncryptionTestUtil.getConfigPath(configDir))
       .configure();
   }
 
@@ -199,9 +202,61 @@ public class EncryptionRequestHandlerTest extends SolrCloudTestCase {
     testUtil.assertQueryReturns("weather", 4);
   }
 
+  @Test
+  public void testDistributionTimeout() throws Exception {
+    // Ensure the next distributed requests will time out.
+    testUtil.setShouldDistributeRequests(true);
+    TestingEncryptionRequestHandler.isDistributionTimeout = true;
+
+    // Send an encrypt request with a key id on an empty index.
+    EncryptionTestUtil.EncryptionStatus encryptionStatus = testUtil.encrypt(KEY_ID_1);
+
+    // Verify that the distribution timeout is handled with the appropriate response status.
+    assertFalse(encryptionStatus.isSuccess());
+    assertFalse(encryptionStatus.isComplete());
+    assertEquals(EncryptionRequestHandler.State.TIMEOUT, encryptionStatus.getCollectionState());
+  }
+
+  @Test
+  public void testDistributionState() throws Exception {
+    // Ensure the next distributed requests will return PENDING state.
+    testUtil.setShouldDistributeRequests(true);
+    TestingEncryptionRequestHandler.mockedDistributedResponseStatus = STATUS_SUCCESS;
+    TestingEncryptionRequestHandler.mockedDistributedResponseState = EncryptionRequestHandler.State.PENDING;
+
+    // Send an encrypt request with a key id on an empty index.
+    EncryptionTestUtil.EncryptionStatus encryptionStatus = testUtil.encrypt(KEY_ID_1);
+
+    // Verify that the distribution is successful with the PENDING state.
+    assertTrue(encryptionStatus.isSuccess());
+    assertEquals(EncryptionRequestHandler.State.PENDING, encryptionStatus.getCollectionState());
+
+    // Ensure the next distributed requests will return BUSY state.
+    TestingEncryptionRequestHandler.mockedDistributedResponseState = EncryptionRequestHandler.State.BUSY;
+
+    // Send an encrypt request with a key id on an empty index.
+    encryptionStatus = testUtil.encrypt(KEY_ID_1);
+
+    // Verify that the distribution is successful with the BUSY state.
+    assertTrue(encryptionStatus.isSuccess());
+    assertEquals(EncryptionRequestHandler.State.BUSY, encryptionStatus.getCollectionState());
+
+    // Ensure the next distributed requests return regular state.
+    TestingEncryptionRequestHandler.mockedDistributedResponseStatus = null;
+    TestingEncryptionRequestHandler.mockedDistributedResponseState = null;
+
+    // Send an encrypt request with a key id on an empty index.
+    encryptionStatus = testUtil.encrypt(KEY_ID_1);
+
+    // Verify that the distribution is successful with the COMPLETE state.
+    assertTrue(encryptionStatus.isSuccess());
+    assertEquals(EncryptionRequestHandler.State.COMPLETE, encryptionStatus.getCollectionState());
+  }
+
   private static void clearMockValues() {
     forceClearText = false;
     soleKeyIdAllowed = null;
+    TestingEncryptionRequestHandler.clearMockedValues();
   }
 
   public static class MockFactory implements EncryptionDirectoryFactory.InnerFactory {

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
@@ -205,7 +205,9 @@ public class EncryptionRequestHandlerTest extends SolrCloudTestCase {
   @Test
   public void testDistributionTimeout() throws Exception {
     // Ensure the next distributed requests will time out.
-    testUtil.setShouldDistributeRequests(true);
+    testUtil
+        .setShouldDistributeRequests(true)
+        .setDistributionTimeoutMs(1); // any value > 0 will trigger the mock timeout.
     TestingEncryptionRequestHandler.isDistributionTimeout = true;
 
     // Send an encrypt request with a key id on an empty index.

--- a/encryption/src/test/java/org/apache/solr/encryption/kms/KmsEncryptionRequestHandlerTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/kms/KmsEncryptionRequestHandlerTest.java
@@ -2,13 +2,10 @@ package org.apache.solr.encryption.kms;
 
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
-import org.apache.solr.cloud.MiniSolrCloudCluster;
-import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
-import org.apache.solr.encryption.EncryptionTestUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.apache.solr.encryption.EncryptionRequestHandlerTest;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.apache.solr.encryption.EncryptionRequestHandler.PARAM_KEY_ID;
@@ -18,19 +15,10 @@ import static org.apache.solr.encryption.kms.KmsEncryptionRequestHandler.PARAM_T
 /**
  * Tests {@link KmsEncryptionRequestHandler}.
  */
-public class KmsEncryptionRequestHandlerTest extends SolrCloudTestCase {
+public class KmsEncryptionRequestHandlerTest extends EncryptionRequestHandlerTest {
 
-  @BeforeClass
-  public static void beforeClass() throws Exception {
-    EncryptionTestUtil.setInstallDirProperty();
-    cluster = new MiniSolrCloudCluster.Builder(2, createTempDir())
-            .addConfig("config", EncryptionTestUtil.getConfigPath("collection1"))
-            .configure();
-  }
-
-  @AfterClass
-  public static void afterClass() throws Exception {
-    cluster.shutdown();
+  static {
+    configDir = "kms";
   }
 
   @Test(expected = SolrException.class)
@@ -48,4 +36,16 @@ public class KmsEncryptionRequestHandlerTest extends SolrCloudTestCase {
     params.set(PARAM_ENCRYPTION_KEY_BLOB, "keyBlob");
     cluster.getSolrClient().request(new GenericSolrRequest(SolrRequest.METHOD.GET, "/admin/encrypt", params));
   }
+
+  @Ignore
+  @Override
+  // Do not test timeout because the "kms" config does not define the TestingEncryptionRequestHandler
+  // required for the test.
+  public void testDistributionTimeout() {}
+
+  @Ignore
+  @Test
+  // Do not test state because the "kms" config does not define the TestingEncryptionRequestHandler
+  // required for the test.
+  public void testDistributionState() {}
 }


### PR DESCRIPTION
The client can call EncryptionRequestHandler and provide the additional parameter "distrib" = "true". In this case, this handler will distribute the encryption request to all the leader replicas of all the shards of the collection, ensuring they all encrypt their index shard. The response "encryptionState" will be "complete" only when all the shards return "complete". So the caller may repeatedly send the same encryption request with "distrib" = "true" to know when the whole collection encryption is complete. In addition, the caller can set the "timeAllowed" parameter to define a timeout for the request distribution, in milliseconds. This timeout is for the distribution itself, not the encryption process.