### PR TITLE
Encryption IndexInput and IndexOutput can be unwrapped. More doc about IV construction.

### DIFF
--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectory.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionDirectory.java
@@ -275,7 +275,7 @@ public class EncryptionDirectory extends FilterDirectory {
    */
   protected String getKeyRefForReading(IndexInput indexInput) throws IOException {
     // Always reading the magic number, even for non-encrypted indexes, is not a performance
-    // issue because it will be read immediately again when the Directory is returned, to
+    // issue because it will be read immediately again when the IndexInput is returned, to
     // check the index header (CodecUtil.checkIndexHeader()).
     long filePointer = indexInput.getFilePointer();
     int magic = readBEInt(indexInput);

--- a/encryption/src/main/java/org/apache/solr/encryption/crypto/AesCtrEncrypter.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/crypto/AesCtrEncrypter.java
@@ -23,6 +23,7 @@ package org.apache.solr.encryption.crypto;
  * <p>An {@link AesCtrEncrypter} must be first {@link #init(long) initialized} before it can be used to
  * {@link #process encrypt/decrypt}.
  * <p>Not thread safe.
+ * <p>See {@link AesCtrUtil} for internal doc about the choice of CTR mode.
  */
 public interface AesCtrEncrypter extends Cloneable {
 

--- a/encryption/src/main/java/org/apache/solr/encryption/crypto/EncryptingIndexOutput.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/crypto/EncryptingIndexOutput.java
@@ -17,6 +17,7 @@
 package org.apache.solr.encryption.crypto;
 
 import org.apache.lucene.store.BufferedChecksum;
+import org.apache.lucene.store.FilterIndexOutput;
 import org.apache.lucene.store.IndexOutput;
 
 import java.io.IOException;
@@ -32,11 +33,12 @@ import static org.apache.solr.encryption.crypto.AesCtrUtil.*;
  * <p>It generates a cryptographically strong random CTR Initialization Vector (IV). This random IV is not encrypted and
  * is skipped by any {@link DecryptingIndexInput} reading the written data. Then it can encrypt the rest of the file
  * which probably contains a header and footer.
+ * <p>It is a {@link FilterIndexOutput}, so it is possible to {@link FilterIndexOutput#unwrap} it.
  *
  * @see DecryptingIndexInput
  * @see AesCtrEncrypter
  */
-public class EncryptingIndexOutput extends IndexOutput {
+public class EncryptingIndexOutput extends FilterIndexOutput {
 
   /**
    * Must be a multiple of {@link AesCtrUtil#AES_BLOCK_SIZE}.
@@ -81,7 +83,7 @@ public class EncryptingIndexOutput extends IndexOutput {
                                AesCtrEncrypterFactory factory,
                                int bufferCapacity)
     throws IOException {
-    super("Encrypting " + indexOutput.toString(), indexOutput.getName());
+    super("Encrypting " + indexOutput, indexOutput.getName(), indexOutput);
     this.indexOutput = indexOutput;
     byte[] iv = generateRandomIv();
     encrypter = factory.create(key, iv);


### PR DESCRIPTION
Makes DecryptingIndexInput extend FilterIndexInput, and EncryptingIndexOutput extend FilterIndexOutput, in case one need to unwrap the Filter input/output.

Also adds more doc about the choice of the CTR-mode, and the nonce-misuse resistance when building the random IV.