### PR TITLE
Add missing Thread.interrupt() call in EncryptionRequestHandler.

### DIFF
--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionRequestHandler.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionRequestHandler.java
@@ -395,6 +395,7 @@ public class EncryptionRequestHandler extends RequestHandlerBase {
           }
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         collectionState = State.INTERRUPTED;
       }
       success = collectionState == null || collectionState.isSuccess();


### PR DESCRIPTION
Single line added: call Thread.interrupt() in try-catch InterruptedException.