### PR TITLE
Add isIndexEncrypted flag and encryption listener.

### DIFF
--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionMergePolicy.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionMergePolicy.java
@@ -74,7 +74,12 @@ public class EncryptionMergePolicy extends FilterMergePolicy {
     // Make sure the EncryptionDirectory does not keep its cache for the commit user data.
     // It must read the latest commit user data to get the latest active key, so below the
     // segments with old key (to re-encrypt) are always accurate.
-    encryptionDir.forceReadCommitUserData();
+    encryptionDir.clearCachedCommitUserData();
+    // Also clear the encryption status for logs if the index becomes cleartext after rewriting
+    // the segments.
+    if (activeKeyId == null) {
+      encryptionDir.clearCachedEncryptionStatus();
+    }
     List<SegmentCommitInfo> segmentsWithOldKeyId = encryptionDir.getSegmentsWithOldKeyId(segmentInfos, activeKeyId);
     if (segmentsWithOldKeyId.isEmpty()) {
       return null;

--- a/encryption/src/main/java/org/apache/solr/encryption/EncryptionUpdateLog.java
+++ b/encryption/src/main/java/org/apache/solr/encryption/EncryptionUpdateLog.java
@@ -98,7 +98,7 @@ public class EncryptionUpdateLog extends UpdateLog {
     String activeKeyRef;
     EncryptionDirectory directory = directorySupplier.get();
     try {
-      directory.forceReadCommitUserData();
+      directory.clearCachedCommitUserData();
       latestCommitData = directory.getLatestCommitData().data;
       activeKeyRef = getActiveKeyRefFromCommit(latestCommitData);
       for (TransactionLog log : logs) {

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionBackupRepositoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionBackupRepositoryTest.java
@@ -182,7 +182,11 @@ public class EncryptionBackupRepositoryTest extends AbstractBackupRepositoryTest
         AesCtrEncrypterFactory encrypterFactory = random().nextBoolean() ? CipherAesCtrEncrypter.FACTORY : LightAesCtrEncrypter.FACTORY;
         KeySupplier keySupplier = new TestingKeySupplier.Factory().create();
         try (Directory fsSourceDir = FSDirectory.open(sourcePath);
-             Directory encSourceDir = new TestEncryptionDirectory(fsSourceDir, encrypterFactory, keySupplier);
+             Directory encSourceDir = new TestEncryptionDirectory(
+                 fsSourceDir,
+                 encrypterFactory,
+                 keySupplier,
+                 EncryptionDirectory.EncryptionListener.NO_LISTENER);
              Directory destinationDir = FSDirectory.open(createTempDir().toAbsolutePath())) {
             String fileName = "source-file";
             String content = "content";
@@ -331,9 +335,13 @@ public class EncryptionBackupRepositoryTest extends AbstractBackupRepositoryTest
      */
     private static class TestEncryptionDirectory extends EncryptionDirectory {
 
-        TestEncryptionDirectory(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeySupplier keySupplier)
-                throws IOException {
-            super(delegate, encrypterFactory, keySupplier);
+        TestEncryptionDirectory(
+            Directory delegate,
+            AesCtrEncrypterFactory encrypterFactory,
+            KeySupplier keySupplier,
+            EncryptionListener encryptionListener)
+            throws IOException {
+            super(delegate, encrypterFactory, keySupplier, encryptionListener);
         }
 
         @Override

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionDirectoryTest.java
@@ -262,8 +262,10 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
     @Override
     public EncryptionDirectory create(Directory delegate,
                                       AesCtrEncrypterFactory encrypterFactory,
-                                      KeySupplier keySupplier) throws IOException {
-      MockEncryptionDirectory mockDir = new MockEncryptionDirectory(delegate, encrypterFactory, keySupplier);
+                                      KeySupplier keySupplier,
+                                      EncryptionDirectory.EncryptionListener encryptionListener)
+        throws IOException {
+      MockEncryptionDirectory mockDir = new MockEncryptionDirectory(delegate, encrypterFactory, keySupplier, encryptionListener);
       mockDirs.add(mockDir);
       return mockDir;
     }
@@ -273,9 +275,13 @@ public class EncryptionDirectoryTest extends SolrCloudTestCase {
 
     final KeySupplier keySupplier;
 
-    MockEncryptionDirectory(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeySupplier keySupplier)
+    MockEncryptionDirectory(
+        Directory delegate,
+        AesCtrEncrypterFactory encrypterFactory,
+        KeySupplier keySupplier,
+        EncryptionListener encryptionListener)
       throws IOException {
-      super(delegate, encrypterFactory, keySupplier);
+      super(delegate, encrypterFactory, keySupplier, encryptionListener);
       this.keySupplier = keySupplier;
     }
 

--- a/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
+++ b/encryption/src/test/java/org/apache/solr/encryption/EncryptionRequestHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.embedded.JettySolrRunner;
 import org.apache.solr.encryption.crypto.AesCtrEncrypterFactory;
+import org.apache.solr.encryption.EncryptionDirectory.EncryptionListener;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequestBase;
 import org.apache.solr.response.SolrQueryResponse;
@@ -393,16 +394,22 @@ public class EncryptionRequestHandlerTest extends SolrCloudTestCase {
     @Override
     public EncryptionDirectory create(Directory delegate,
                                       AesCtrEncrypterFactory encrypterFactory,
-                                      KeySupplier keySupplier) throws IOException {
-      return new MockEncryptionDirectory(delegate, encrypterFactory, keySupplier);
+                                      KeySupplier keySupplier,
+                                      EncryptionListener encryptionListener)
+        throws IOException {
+      return new MockEncryptionDirectory(delegate, encrypterFactory, keySupplier, encryptionListener);
     }
   }
 
   private static class MockEncryptionDirectory extends EncryptionDirectory {
 
-    MockEncryptionDirectory(Directory delegate, AesCtrEncrypterFactory encrypterFactory, KeySupplier keySupplier)
+    MockEncryptionDirectory(
+        Directory delegate,
+        AesCtrEncrypterFactory encrypterFactory,
+        KeySupplier keySupplier,
+        EncryptionListener encryptionListener)
       throws IOException {
-      super(delegate, encrypterFactory, keySupplier);
+      super(delegate, encrypterFactory, keySupplier, encryptionListener);
     }
 
     @Override


### PR DESCRIPTION
A new flag EncryptionDirectoryFactory.isIndexEnabled() is set when the EncryptionDirectory opens an output/input stream that requires encryption. For example, this may allow some custom code to log whether the index is encrypted.